### PR TITLE
Scaffold Codex Cage CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.DS_Store
+node_modules/
+dist/
+coverage/
+issues/
+scripts/
+PRD.md
+recap.md
+.codex-cage.env
+.codex-cage/runs/
+.codex-cage/*.sqlite

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=true

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "printWidth": 90,
+  "trailingComma": "all"
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Codex Cage
+
+Codex Cage is a lightweight CLI for running Codex against issue-driven work in an isolated Docker workspace. The project is currently in early scaffold form: the CLI exists, `init` works, and the later run/orchestration commands are intentionally stubbed until their implementation slices land.
+
+## Current Commands
+
+```bash
+codex-cage --help
+codex-cage init
+codex-cage init --dockerfile
+codex-cage run --issue <url>
+codex-cage runs list
+codex-cage runs show <run-id>
+codex-cage cleanup
+```
+
+Only `init` is implemented right now. Other commands are routed and documented in help output, but return a not-implemented error.
+
+## Initialize a Target Repo
+
+```bash
+codex-cage init
+```
+
+This creates:
+
+- `.codex-cage.yml`
+- `.codex-cage.env.example`
+- `.gitignore` entries for local Codex Cage runtime state
+
+Use `--dockerfile` when the target repo needs custom system packages:
+
+```bash
+codex-cage init --dockerfile
+```
+
+The generated verify command intentionally fails until replaced with the target repo's real test command.
+
+## Development
+
+```bash
+npm install
+npm run typecheck
+npm test
+npm run format
+```
+
+If the default npm cache has local permission problems, use a temporary cache for package smoke checks:
+
+```bash
+npm --cache /tmp/codex-cage-npm-cache exec -- codex-cage --help
+npm --cache /tmp/codex-cage-npm-cache pack --dry-run
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,423 @@
+{
+  "name": "codex-cage",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "codex-cage",
+      "version": "0.1.0",
+      "dependencies": {
+        "commander": "^13.1.0",
+        "execa": "^9.5.2",
+        "sql.js": "^1.12.0",
+        "yaml": "^2.7.0",
+        "zod": "^3.24.2"
+      },
+      "bin": {
+        "codex-cage": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.13.1",
+        "@types/sql.js": "^1.4.9",
+        "prettier": "^3.5.1",
+        "typescript": "^5.7.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/sql.js": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
+      "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "codex-cage",
+  "version": "0.1.0",
+  "description": "Run Codex in an isolated Docker workspace and publish verified PRs from issue links.",
+  "type": "module",
+  "bin": {
+    "codex-cage": "./dist/src/cli.js"
+  },
+  "files": [
+    "dist/src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "npm run build && node --test \"dist/test/**/*.test.js\"",
+    "lint": "npm run typecheck",
+    "format": "prettier --check ."
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "dependencies": {
+    "commander": "^13.1.0",
+    "execa": "^9.5.2",
+    "sql.js": "^1.12.0",
+    "yaml": "^2.7.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.1",
+    "@types/sql.js": "^1.4.9",
+    "prettier": "^3.5.1",
+    "typescript": "^5.7.3"
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import { createCli } from "./commands.js";
+
+const program = createCli();
+
+await program.parseAsync(process.argv);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,69 @@
+import { Command } from "commander";
+import { initProject } from "./init.js";
+import { readPackageVersion } from "./version.js";
+
+type CommandHandler = () => Promise<void> | void;
+
+const notImplemented =
+  (commandName: string): CommandHandler =>
+  () => {
+    throw new Error(`${commandName} is not implemented yet.`);
+  };
+
+export function createCli(): Command {
+  const program = new Command();
+
+  program
+    .name("codex-cage")
+    .description(
+      "Run Codex in an isolated Docker workspace and publish verified PRs from issue links.",
+    )
+    .version(readPackageVersion());
+
+  program
+    .command("init")
+    .description("Create Codex Cage config files in the current repository.")
+    .option("--dockerfile", "also create .codex-cage/Dockerfile")
+    .action(async (options: { dockerfile?: boolean }) => {
+      const result = await initProject(process.cwd(), options);
+
+      for (const path of result.created) {
+        console.log(`created ${path}`);
+      }
+
+      for (const path of result.updated) {
+        console.log(`updated ${path}`);
+      }
+    });
+
+  program
+    .command("run")
+    .description("Run Codex Cage for a GitHub or Linear issue URL.")
+    .requiredOption("--issue <url>", "GitHub or Linear issue URL")
+    .option("--repo <repo>", "target GitHub repository override")
+    .option("--base <branch>", "base branch override")
+    .option("--model <model>", "Codex model override")
+    .option("--draft", "create a draft pull request")
+    .action(notImplemented("run"));
+
+  const runs = program.command("runs").description("Inspect prior Codex Cage runs.");
+
+  runs
+    .command("list")
+    .description("List known runs from local metadata.")
+    .action(notImplemented("runs list"));
+
+  runs
+    .command("show")
+    .description("Show metadata and artifact paths for a run.")
+    .argument("<run-id>", "run id")
+    .action(notImplemented("runs show"));
+
+  program
+    .command("cleanup")
+    .description("Remove stale Docker resources managed by Codex Cage.")
+    .option("--all", "remove all managed Docker resources, including active ones")
+    .action(notImplemented("cleanup"));
+
+  return program;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+
+export const codexCageConfigSchema = z
+  .object({
+    setup: z.array(z.string()).default([]),
+    verify: z.array(z.string()).min(1),
+    services: z
+      .object({
+        compose: z.string().nullable().default(null),
+        ready: z.array(z.string()).default([]),
+      })
+      .default(() => ({ compose: null, ready: [] })),
+    agent: z
+      .object({
+        model: z.string().default("gpt-5.4"),
+        max_iterations: z.number().int().positive().default(5),
+        max_review_cycles: z.number().int().nonnegative().default(2),
+      })
+      .default(() => ({ model: "gpt-5.4", max_iterations: 5, max_review_cycles: 2 })),
+    timeouts: z
+      .object({
+        total_minutes: z.number().int().positive().default(90),
+        command_minutes: z.number().int().positive().default(20),
+        idle_minutes: z.number().int().positive().default(10),
+      })
+      .default(() => ({ total_minutes: 90, command_minutes: 20, idle_minutes: 10 })),
+    pr: z
+      .object({
+        draft: z.boolean().default(false),
+      })
+      .default(() => ({ draft: false })),
+    git: z
+      .object({
+        base: z.string().default("main"),
+        author_name: z.string().default("Codex Cage"),
+        author_email: z.string().email().default("codex-cage@users.noreply.github.com"),
+      })
+      .default(() => ({
+        base: "main",
+        author_name: "Codex Cage",
+        author_email: "codex-cage@users.noreply.github.com",
+      })),
+    issue: z
+      .object({
+        comments: z.union([z.number().int().nonnegative(), z.literal("all")]).default(10),
+      })
+      .default(() => ({ comments: 10 })),
+    guards: z
+      .object({
+        max_secret_fix_attempts: z.number().int().nonnegative().default(2),
+      })
+      .default(() => ({ max_secret_fix_attempts: 2 })),
+  })
+  .passthrough();
+
+export type CodexCageConfig = z.infer<typeof codexCageConfigSchema>;
+
+export type ConfigParseResult = {
+  config: CodexCageConfig;
+  warnings: string[];
+};
+
+const knownTopLevelKeys = new Set([
+  "setup",
+  "verify",
+  "services",
+  "agent",
+  "timeouts",
+  "pr",
+  "git",
+  "issue",
+  "guards",
+]);
+
+export function parseCodexCageConfig(input: unknown): ConfigParseResult {
+  const warnings = collectUnknownTopLevelKeyWarnings(input);
+
+  return {
+    config: codexCageConfigSchema.parse(input),
+    warnings,
+  };
+}
+
+function collectUnknownTopLevelKeyWarnings(input: unknown): string[] {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    return [];
+  }
+
+  return Object.keys(input)
+    .filter((key) => !knownTopLevelKeys.has(key))
+    .map((key) => `Unknown config key "${key}" is not used by this version.`);
+}

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,193 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+
+export type InitOptions = {
+  dockerfile?: boolean;
+};
+
+export type InitResult = {
+  created: string[];
+  updated: string[];
+};
+
+const configPath = ".codex-cage.yml";
+const envExamplePath = ".codex-cage.env.example";
+const gitignorePath = ".gitignore";
+const dockerfilePath = ".codex-cage/Dockerfile";
+
+const defaultConfig = `# Codex Cage target repo configuration.
+# Replace the verify command before running Codex Cage.
+setup: []
+
+verify:
+  - echo "Replace this with your real test command" && exit 1
+
+services:
+  compose: null
+  ready: []
+
+agent:
+  model: gpt-5.4
+  max_iterations: 5
+  max_review_cycles: 2
+
+timeouts:
+  total_minutes: 90
+  command_minutes: 20
+  idle_minutes: 10
+
+pr:
+  draft: false
+
+git:
+  base: main
+  author_name: Codex Cage
+  author_email: codex-cage@users.noreply.github.com
+
+issue:
+  comments: 10
+
+guards:
+  max_secret_fix_attempts: 2
+`;
+
+const envExample = `# Copy this file to .codex-cage.env and fill in local secrets.
+OPENAI_API_KEY=
+GITHUB_TOKEN=
+# Required only for Linear issue URLs.
+LINEAR_API_KEY=
+`;
+
+const dockerfile = `FROM node:22-bookworm
+
+# Add target-repo system dependencies here.
+`;
+
+const gitignoreEntries = [".codex-cage.env", ".codex-cage/runs/", ".codex-cage/*.sqlite"];
+
+export async function initProject(
+  cwd: string,
+  options: InitOptions = {},
+): Promise<InitResult> {
+  const created: string[] = [];
+  const updated: string[] = [];
+  const configFilePath = join(cwd, configPath);
+  const dockerfileFilePath = join(cwd, dockerfilePath);
+
+  await assertFileDoesNotExist(cwd, configFilePath);
+
+  if (options.dockerfile) {
+    await assertFileDoesNotExist(cwd, dockerfileFilePath);
+  }
+
+  await createFileOnce(cwd, configFilePath, defaultConfig, created);
+  await mergeEnvExample(cwd, join(cwd, envExamplePath), created, updated);
+  await appendGitignoreEntries(cwd, join(cwd, gitignorePath), updated);
+
+  if (options.dockerfile) {
+    await createFileOnce(cwd, dockerfileFilePath, dockerfile, created);
+  }
+
+  return { created, updated };
+}
+
+async function createFileOnce(
+  cwd: string,
+  path: string,
+  content: string,
+  created: string[],
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, "utf8");
+  created.push(relativeDisplayPath(cwd, path));
+}
+
+async function assertFileDoesNotExist(cwd: string, path: string): Promise<void> {
+  if (await fileExists(path)) {
+    throw new Error(`${relativeDisplayPath(cwd, path)} already exists.`);
+  }
+}
+
+async function mergeEnvExample(
+  cwd: string,
+  path: string,
+  created: string[],
+  updated: string[],
+): Promise<void> {
+  if (!(await fileExists(path))) {
+    await writeFile(path, envExample, "utf8");
+    created.push(relativeDisplayPath(cwd, path));
+    return;
+  }
+
+  const current = await readFile(path, "utf8");
+  const currentKeys = new Set(
+    current
+      .split(/\r?\n/)
+      .map((line) => line.match(/^([A-Z0-9_]+)=/)?.[1])
+      .filter((key): key is string => key !== undefined),
+  );
+  const missingLines = envExample
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .filter((line) => {
+      const key = line.match(/^([A-Z0-9_]+)=/)?.[1];
+      return key === undefined || !currentKeys.has(key);
+    })
+    .filter((line) => !current.includes(line));
+
+  if (missingLines.length === 0) {
+    return;
+  }
+
+  const separator = current.endsWith("\n") ? "" : "\n";
+  await writeFile(path, `${current}${separator}${missingLines.join("\n")}\n`, "utf8");
+  updated.push(relativeDisplayPath(cwd, path));
+}
+
+async function appendGitignoreEntries(
+  cwd: string,
+  path: string,
+  updated: string[],
+): Promise<void> {
+  const current = (await readOptionalFile(path)) ?? "";
+  const lines = new Set(
+    current
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean),
+  );
+  const missing = gitignoreEntries.filter((entry) => !lines.has(entry));
+
+  if (missing.length === 0) {
+    return;
+  }
+
+  const separator = current === "" || current.endsWith("\n") ? "" : "\n";
+  await writeFile(path, `${current}${separator}${missing.join("\n")}\n`, "utf8");
+  updated.push(relativeDisplayPath(cwd, path));
+}
+
+async function readOptionalFile(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  return (await readOptionalFile(path)) !== undefined;
+}
+
+function relativeDisplayPath(cwd: string, path: string): string {
+  return relative(cwd, path);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,34 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+type PackageJson = {
+  version?: unknown;
+};
+
+export function readPackageVersion(): string {
+  const packagePath = findPackageJson(dirname(fileURLToPath(import.meta.url)));
+  const packageJson = JSON.parse(readFileSync(packagePath, "utf8")) as PackageJson;
+
+  if (typeof packageJson.version !== "string") {
+    return "0.0.0";
+  }
+
+  return packageJson.version;
+}
+
+function findPackageJson(startDir: string): string {
+  let currentDir = startDir;
+
+  while (currentDir !== dirname(currentDir)) {
+    const candidate = join(currentDir, "package.json");
+
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+
+    currentDir = dirname(currentDir);
+  }
+
+  return join(startDir, "package.json");
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(testDir, "..", "src", "cli.js");
+
+function runCli(args: string[]) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    encoding: "utf8",
+  });
+}
+
+test("root help lists MVP commands", () => {
+  const result = runCli(["--help"]);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Usage: codex-cage/);
+  assert.match(result.stdout, /\binit\b/);
+  assert.match(result.stdout, /\brun\b/);
+  assert.match(result.stdout, /\bruns\b/);
+  assert.match(result.stdout, /\bcleanup\b/);
+});
+
+test("command help is available for MVP commands", () => {
+  const commands = [
+    ["init", "--help"],
+    ["run", "--help"],
+    ["runs", "list", "--help"],
+    ["runs", "show", "--help"],
+    ["cleanup", "--help"],
+  ];
+
+  for (const command of commands) {
+    const result = runCli(command);
+
+    assert.equal(result.status, 0, command.join(" "));
+    assert.match(result.stdout, /Usage:/);
+  }
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { codexCageConfigSchema, parseCodexCageConfig } from "../src/config.js";
+
+test("config schema accepts a minimal valid config", () => {
+  const config = codexCageConfigSchema.parse({
+    verify: ["npm test"],
+  });
+
+  assert.deepEqual(config.setup, []);
+  assert.deepEqual(config.verify, ["npm test"]);
+  assert.equal(config.git.base, "main");
+  assert.equal(config.pr.draft, false);
+  assert.equal(config.issue.comments, 10);
+});
+
+test("config schema rejects empty verify commands", () => {
+  assert.throws(
+    () =>
+      codexCageConfigSchema.parse({
+        verify: [],
+      }),
+    /Array must contain at least 1 element/,
+  );
+});
+
+test("config schema preserves unknown keys for forward compatibility", () => {
+  const result = parseCodexCageConfig({
+    verify: ["npm test"],
+    future_option: true,
+  });
+
+  assert.equal(result.config.future_option, true);
+  assert.deepEqual(result.warnings, [
+    'Unknown config key "future_option" is not used by this version.',
+  ]);
+});

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { initProject } from "../src/init.js";
+
+async function tempRepo(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "codex-cage-init-"));
+}
+
+test("init creates config, env example, and gitignore entries", async () => {
+  const cwd = await tempRepo();
+
+  try {
+    const result = await initProject(cwd);
+
+    assert.deepEqual(result.created, [".codex-cage.yml", ".codex-cage.env.example"]);
+    assert.deepEqual(result.updated, [".gitignore"]);
+
+    const config = await readFile(join(cwd, ".codex-cage.yml"), "utf8");
+    assert.match(config, /verify:/);
+    assert.match(config, /Replace this with your real test command/);
+
+    const envExample = await readFile(join(cwd, ".codex-cage.env.example"), "utf8");
+    assert.match(envExample, /OPENAI_API_KEY=/);
+    assert.match(envExample, /GITHUB_TOKEN=/);
+
+    const gitignore = await readFile(join(cwd, ".gitignore"), "utf8");
+    assert.match(gitignore, /\.codex-cage\.env/);
+    assert.match(gitignore, /\.codex-cage\/runs\//);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("init refuses to overwrite existing config", async () => {
+  const cwd = await tempRepo();
+
+  try {
+    await writeFile(join(cwd, ".codex-cage.yml"), "verify:\n  - npm test\n", "utf8");
+
+    await assert.rejects(() => initProject(cwd), /\.codex-cage\.yml already exists/);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("init can create optional Dockerfile", async () => {
+  const cwd = await tempRepo();
+
+  try {
+    const result = await initProject(cwd, { dockerfile: true });
+
+    assert.ok(result.created.includes(".codex-cage/Dockerfile"));
+    const dockerfile = await readFile(join(cwd, ".codex-cage", "Dockerfile"), "utf8");
+    assert.match(dockerfile, /FROM node:22-bookworm/);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("init refuses to partially initialize when optional Dockerfile exists", async () => {
+  const cwd = await tempRepo();
+
+  try {
+    await writeFile(join(cwd, ".gitignore"), "node_modules/\n", "utf8");
+    await initProject(cwd);
+    await rm(join(cwd, ".codex-cage.yml"), { force: true });
+    await mkdir(join(cwd, ".codex-cage"), { recursive: true });
+    await writeFile(join(cwd, ".codex-cage", "Dockerfile"), "FROM custom\n", "utf8");
+
+    await assert.rejects(
+      () => initProject(cwd, { dockerfile: true }),
+      /\.codex-cage\/Dockerfile already exists/,
+    );
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": ".",
+    "outDir": "dist",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Add the TypeScript Node CLI scaffold and package metadata for the `codex-cage` binary.
- Implement command routing for init/run/runs/cleanup and a working `codex-cage init` flow.
- Add the required config schema and tests for CLI/config/init behavior.
- Add README.md for current usage and development commands.
- Tighten TypeScript compiler settings and init/config implementation details after review.

## Verification
- `npm run typecheck`
- `npm test`
- `npm run format`
- `npm --cache /tmp/codex-cage-npm-cache exec -- codex-cage --help`
- `npm --cache /tmp/codex-cage-npm-cache pack --dry-run`

Closes #2
Closes #3