### PR TITLE
Fetch issue context

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ codex-cage runs show <run-id>
 
 Run metadata is stored in `.codex-cage/codex-cage.sqlite`. Large artifacts such as logs, patches, issue payloads, and summaries are stored under `.codex-cage/runs/<run-id>` rather than inside SQLite.
 
+## Issue Context
+
+Codex Cage supports GitHub and Linear issue URLs as normalized task context.
+
+- GitHub issue URLs infer the target repo from the URL.
+- Linear issue URLs infer the issue key from the URL, but the target repo must come from a later repo-resolution step.
+- GitHub context uses `GITHUB_TOKEN` when provided.
+- Linear context requires `LINEAR_API_KEY`.
+- Empty comments and known bot comments are filtered out.
+- The default issue context includes the last 10 human comments.
+
 ## Development
 
 ```bash

--- a/src/issue.ts
+++ b/src/issue.ts
@@ -1,0 +1,342 @@
+export type IssueSource = "github" | "linear";
+
+export type IssueComment = {
+  author: string;
+  body: string;
+  createdAt: string | null;
+};
+
+export type IssueContext = {
+  source: IssueSource;
+  url: string;
+  identifier: string;
+  title: string;
+  body: string;
+  comments: IssueComment[];
+  inferredRepo: string | null;
+};
+
+export type CommentSelection = number | "all";
+
+export type FetchIssueContextOptions = {
+  comments?: CommentSelection;
+  githubToken?: string;
+  linearApiKey?: string;
+  fetch?: typeof fetch;
+};
+
+export type ParsedGithubIssueUrl = {
+  source: "github";
+  url: string;
+  owner: string;
+  repo: string;
+  number: number;
+  inferredRepo: string;
+};
+
+export type ParsedLinearIssueUrl = {
+  source: "linear";
+  url: string;
+  organization: string;
+  key: string;
+};
+
+export type ParsedIssueUrl = ParsedGithubIssueUrl | ParsedLinearIssueUrl;
+
+type GithubIssueResponse = {
+  number?: unknown;
+  title?: unknown;
+  body?: unknown;
+};
+
+type GithubCommentResponse = {
+  body?: unknown;
+  created_at?: unknown;
+  user?: {
+    login?: unknown;
+    type?: unknown;
+  } | null;
+};
+
+type LinearGraphQlResponse = {
+  data?: {
+    issue?: {
+      identifier?: unknown;
+      title?: unknown;
+      description?: unknown;
+      comments?: {
+        nodes?: Array<{
+          body?: unknown;
+          createdAt?: unknown;
+          user?: {
+            name?: unknown;
+            displayName?: unknown;
+          } | null;
+        }>;
+      } | null;
+    } | null;
+  };
+  errors?: Array<{ message?: unknown }>;
+};
+
+const defaultCommentSelection = 10;
+const knownBotNamePattern = /\b(bot|github-actions)\b|dependabot/i;
+
+export function parseIssueUrl(issueUrl: string): ParsedIssueUrl {
+  const url = parseUrl(issueUrl);
+
+  if (url.hostname === "github.com") {
+    return parseGithubIssueUrl(url);
+  }
+
+  if (url.hostname === "linear.app") {
+    return parseLinearIssueUrl(url);
+  }
+
+  throw new Error(`Unsupported issue URL host: ${url.hostname}`);
+}
+
+export async function fetchIssueContext(
+  issueUrl: string,
+  options: FetchIssueContextOptions = {},
+): Promise<IssueContext> {
+  const parsed = parseIssueUrl(issueUrl);
+
+  if (parsed.source === "github") {
+    return await fetchGithubIssueContext(parsed, options);
+  }
+
+  return await fetchLinearIssueContext(parsed, options);
+}
+
+export async function fetchGithubIssueContext(
+  issue: ParsedGithubIssueUrl,
+  options: FetchIssueContextOptions = {},
+): Promise<IssueContext> {
+  const fetcher = options.fetch ?? fetch;
+  const headers = githubHeaders(options.githubToken);
+  const issueApiUrl = `https://api.github.com/repos/${issue.owner}/${issue.repo}/issues/${issue.number}`;
+  const commentsApiUrl = `${issueApiUrl}/comments`;
+  const [issuePayload, commentsPayload] = await Promise.all([
+    requestJson<GithubIssueResponse>(fetcher, issueApiUrl, { headers }),
+    requestJson<GithubCommentResponse[]>(fetcher, commentsApiUrl, { headers }),
+  ]);
+  const comments = selectComments(
+    commentsPayload.map((comment) => ({
+      author: readOptionalString(comment.user?.login) ?? "unknown",
+      authorType: readOptionalString(comment.user?.type),
+      body: readOptionalString(comment.body) ?? "",
+      createdAt: readOptionalString(comment.created_at),
+    })),
+    options.comments ?? defaultCommentSelection,
+  );
+
+  return {
+    source: "github",
+    url: issue.url,
+    identifier: `#${issue.number}`,
+    title: readRequiredString(issuePayload.title, "GitHub issue title"),
+    body: readOptionalString(issuePayload.body) ?? "",
+    comments,
+    inferredRepo: issue.inferredRepo,
+  };
+}
+
+export async function fetchLinearIssueContext(
+  issue: ParsedLinearIssueUrl,
+  options: FetchIssueContextOptions = {},
+): Promise<IssueContext> {
+  if (options.linearApiKey === undefined || options.linearApiKey.trim() === "") {
+    throw new Error("Linear issue URLs require LINEAR_API_KEY.");
+  }
+
+  const fetcher = options.fetch ?? fetch;
+  const response = await requestJson<LinearGraphQlResponse>(
+    fetcher,
+    "https://api.linear.app/graphql",
+    {
+      method: "POST",
+      headers: {
+        Authorization: options.linearApiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: `
+          query CodexCageIssue($id: String!) {
+            issue(id: $id) {
+              identifier
+              title
+              description
+              comments {
+                nodes {
+                  body
+                  createdAt
+                  user {
+                    name
+                    displayName
+                  }
+                }
+              }
+            }
+          }
+        `,
+        variables: { id: issue.key },
+      }),
+    },
+  );
+
+  if (response.errors !== undefined && response.errors.length > 0) {
+    const message = readOptionalString(response.errors[0]?.message) ?? "unknown error";
+    throw new Error(`Linear API error: ${message}`);
+  }
+
+  const payload = response.data?.issue;
+
+  if (payload === null || payload === undefined) {
+    throw new Error(`Linear issue ${issue.key} was not found.`);
+  }
+
+  const comments = selectComments(
+    (payload.comments?.nodes ?? []).map((comment) => ({
+      author:
+        readOptionalString(comment.user?.displayName) ??
+        readOptionalString(comment.user?.name) ??
+        "unknown",
+      authorType: null,
+      body: readOptionalString(comment.body) ?? "",
+      createdAt: readOptionalString(comment.createdAt),
+    })),
+    options.comments ?? defaultCommentSelection,
+  );
+
+  return {
+    source: "linear",
+    url: issue.url,
+    identifier: readOptionalString(payload.identifier) ?? issue.key,
+    title: readRequiredString(payload.title, "Linear issue title"),
+    body: readOptionalString(payload.description) ?? "",
+    comments,
+    inferredRepo: null,
+  };
+}
+
+function parseGithubIssueUrl(url: URL): ParsedGithubIssueUrl {
+  const [owner, repo, kind, issueNumber, ...rest] = url.pathname
+    .split("/")
+    .filter(Boolean);
+
+  if (
+    owner === undefined ||
+    repo === undefined ||
+    kind !== "issues" ||
+    issueNumber === undefined ||
+    rest.length > 0
+  ) {
+    throw new Error(
+      "GitHub issue URL must match https://github.com/{owner}/{repo}/issues/{number}",
+    );
+  }
+
+  const number = Number(issueNumber);
+
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new Error(`Invalid GitHub issue number: ${issueNumber}`);
+  }
+
+  return {
+    source: "github",
+    url: url.toString(),
+    owner,
+    repo,
+    number,
+    inferredRepo: `${owner}/${repo}`,
+  };
+}
+
+function parseLinearIssueUrl(url: URL): ParsedLinearIssueUrl {
+  const [organization, kind, key] = url.pathname.split("/").filter(Boolean);
+
+  if (organization === undefined || kind !== "issue" || key === undefined) {
+    throw new Error(
+      "Linear issue URL must match https://linear.app/{org}/issue/{KEY}/...",
+    );
+  }
+
+  return {
+    source: "linear",
+    url: url.toString(),
+    organization,
+    key: key.toUpperCase(),
+  };
+}
+
+function parseUrl(issueUrl: string): URL {
+  try {
+    return new URL(issueUrl);
+  } catch {
+    throw new Error(`Invalid issue URL: ${issueUrl}`);
+  }
+}
+
+type RawComment = IssueComment & {
+  authorType: string | null;
+};
+
+function selectComments(
+  comments: RawComment[],
+  selection: CommentSelection,
+): IssueComment[] {
+  const humanComments = comments
+    .filter((comment) => comment.body.trim() !== "")
+    .filter((comment) => !isBotComment(comment));
+  const selected = selection === "all" ? humanComments : humanComments.slice(-selection);
+
+  return selected.map(({ author, body, createdAt }) => ({
+    author,
+    body,
+    createdAt,
+  }));
+}
+
+function isBotComment(comment: RawComment): boolean {
+  return comment.authorType === "Bot" || knownBotNamePattern.test(comment.author);
+}
+
+async function requestJson<T>(
+  fetcher: typeof fetch,
+  url: string,
+  init?: RequestInit,
+): Promise<T> {
+  const response = await fetcher(url, init);
+
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status} ${response.statusText}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+function githubHeaders(token: string | undefined): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  if (token !== undefined && token.trim() !== "") {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+}
+
+function readRequiredString(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`Expected ${label} to be a string.`);
+  }
+
+  return value;
+}
+
+function readOptionalString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}

--- a/test/issue.test.ts
+++ b/test/issue.test.ts
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  fetchGithubIssueContext,
+  fetchIssueContext,
+  fetchLinearIssueContext,
+  parseIssueUrl,
+  type ParsedGithubIssueUrl,
+  type ParsedLinearIssueUrl,
+} from "../src/issue.js";
+
+type MockResponse = {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json: () => Promise<unknown>;
+};
+
+type FetchCall = {
+  url: string;
+  init: RequestInit | undefined;
+};
+
+function jsonResponse(payload: unknown): MockResponse {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => payload,
+  };
+}
+
+function failingResponse(status: number, statusText: string): MockResponse {
+  return {
+    ok: false,
+    status,
+    statusText,
+    json: async () => ({}),
+  };
+}
+
+function createFetchMock(responses: MockResponse[]): {
+  fetch: typeof fetch;
+  calls: FetchCall[];
+} {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init });
+    const response = responses.shift();
+
+    if (response === undefined) {
+      throw new Error("Unexpected fetch call.");
+    }
+
+    return response as Response;
+  }) as typeof fetch;
+
+  return { fetch: fetchMock, calls };
+}
+
+test("parseIssueUrl parses GitHub issue URLs and infers repo", () => {
+  const parsed = parseIssueUrl("https://github.com/jhowliu/codex-cage/issues/42");
+
+  assert.deepEqual(parsed, {
+    source: "github",
+    url: "https://github.com/jhowliu/codex-cage/issues/42",
+    owner: "jhowliu",
+    repo: "codex-cage",
+    number: 42,
+    inferredRepo: "jhowliu/codex-cage",
+  });
+});
+
+test("parseIssueUrl parses Linear issue URLs and keys", () => {
+  const parsed = parseIssueUrl("https://linear.app/acme/issue/ENG-123/fix-login");
+
+  assert.deepEqual(parsed, {
+    source: "linear",
+    url: "https://linear.app/acme/issue/ENG-123/fix-login",
+    organization: "acme",
+    key: "ENG-123",
+  });
+});
+
+test("parseIssueUrl rejects unsupported issue URLs", () => {
+  assert.throws(
+    () => parseIssueUrl("https://example.com/issue/1"),
+    /Unsupported issue URL host/,
+  );
+});
+
+test("fetchGithubIssueContext fetches issue context and selected human comments", async () => {
+  const issue: ParsedGithubIssueUrl = {
+    source: "github",
+    url: "https://github.com/jhowliu/codex-cage/issues/4",
+    owner: "jhowliu",
+    repo: "codex-cage",
+    number: 4,
+    inferredRepo: "jhowliu/codex-cage",
+  };
+  const { fetch, calls } = createFetchMock([
+    jsonResponse({
+      title: "Persist run metadata",
+      body: "Store metadata in SQLite.",
+    }),
+    jsonResponse([
+      {
+        body: "Older human context",
+        created_at: "2026-04-25T00:00:00Z",
+        user: { login: "alice", type: "User" },
+      },
+      {
+        body: "Bot noise",
+        created_at: "2026-04-25T00:01:00Z",
+        user: { login: "dependabot", type: "Bot" },
+      },
+      {
+        body: "",
+        created_at: "2026-04-25T00:02:00Z",
+        user: { login: "bob", type: "User" },
+      },
+      {
+        body: "Latest human context",
+        created_at: "2026-04-25T00:03:00Z",
+        user: { login: "carol", type: "User" },
+      },
+    ]),
+  ]);
+
+  const context = await fetchGithubIssueContext(issue, {
+    comments: 1,
+    githubToken: "github-token",
+    fetch,
+  });
+
+  assert.equal(context.source, "github");
+  assert.equal(context.identifier, "#4");
+  assert.equal(context.inferredRepo, "jhowliu/codex-cage");
+  assert.equal(context.title, "Persist run metadata");
+  assert.deepEqual(context.comments, [
+    {
+      author: "carol",
+      body: "Latest human context",
+      createdAt: "2026-04-25T00:03:00Z",
+    },
+  ]);
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[0]?.init?.headers, {
+    Accept: "application/vnd.github+json",
+    Authorization: "Bearer github-token",
+    "X-GitHub-Api-Version": "2022-11-28",
+  });
+});
+
+test("fetchLinearIssueContext requires LINEAR_API_KEY", async () => {
+  const issue: ParsedLinearIssueUrl = {
+    source: "linear",
+    url: "https://linear.app/acme/issue/ENG-123/fix-login",
+    organization: "acme",
+    key: "ENG-123",
+  };
+
+  await assert.rejects(
+    () => fetchLinearIssueContext(issue),
+    /Linear issue URLs require LINEAR_API_KEY/,
+  );
+});
+
+test("fetchLinearIssueContext fetches issue context and filters comments", async () => {
+  const issue: ParsedLinearIssueUrl = {
+    source: "linear",
+    url: "https://linear.app/acme/issue/ENG-123/fix-login",
+    organization: "acme",
+    key: "ENG-123",
+  };
+  const { fetch, calls } = createFetchMock([
+    jsonResponse({
+      data: {
+        issue: {
+          identifier: "ENG-123",
+          title: "Fix login",
+          description: "Full PRD",
+          comments: {
+            nodes: [
+              {
+                body: "First human comment",
+                createdAt: "2026-04-25T00:00:00Z",
+                user: { name: "Alice", displayName: null },
+              },
+              {
+                body: "Second human comment",
+                createdAt: "2026-04-25T00:01:00Z",
+                user: { name: "Bob", displayName: "Bobby" },
+              },
+            ],
+          },
+        },
+      },
+    }),
+  ]);
+
+  const context = await fetchLinearIssueContext(issue, {
+    comments: "all",
+    linearApiKey: "linear-token",
+    fetch,
+  });
+
+  assert.equal(context.source, "linear");
+  assert.equal(context.identifier, "ENG-123");
+  assert.equal(context.inferredRepo, null);
+  assert.deepEqual(context.comments, [
+    {
+      author: "Alice",
+      body: "First human comment",
+      createdAt: "2026-04-25T00:00:00Z",
+    },
+    {
+      author: "Bobby",
+      body: "Second human comment",
+      createdAt: "2026-04-25T00:01:00Z",
+    },
+  ]);
+  assert.equal(calls[0]?.url, "https://api.linear.app/graphql");
+  assert.deepEqual(calls[0]?.init?.headers, {
+    Authorization: "linear-token",
+    "Content-Type": "application/json",
+  });
+});
+
+test("fetchIssueContext dispatches based on URL provider", async () => {
+  const { fetch } = createFetchMock([
+    jsonResponse({
+      title: "Issue title",
+      body: "Issue body",
+    }),
+    jsonResponse([]),
+  ]);
+
+  const context = await fetchIssueContext(
+    "https://github.com/jhowliu/codex-cage/issues/5",
+    { fetch },
+  );
+
+  assert.equal(context.source, "github");
+  assert.equal(context.identifier, "#5");
+});
+
+test("fetchIssueContext reports HTTP failures", async () => {
+  const { fetch } = createFetchMock([failingResponse(404, "Not Found")]);
+
+  await assert.rejects(
+    () =>
+      fetchIssueContext("https://github.com/jhowliu/codex-cage/issues/5", {
+        fetch,
+      }),
+    /Request failed: 404 Not Found/,
+  );
+});


### PR DESCRIPTION
## Summary
- Add provider-neutral issue context types and URL parsing for GitHub and Linear issues.
- Fetch GitHub issue title/body/comments through REST and infer the target repo from the issue URL.
- Fetch Linear issue title/description/comments through GraphQL and require `LINEAR_API_KEY`.
- Filter empty and known bot comments, with configurable comment selection.
- Document issue context behavior and add mocked provider tests.

## Verification
- `npm run typecheck`
- `npm test`
- `npm run format`
- `npm --cache /tmp/codex-cage-npm-cache exec -- codex-cage --help`
- `npm --cache /tmp/codex-cage-npm-cache pack --dry-run`

Closes #5