### PR TITLE
Resolve target repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ Codex Cage supports GitHub and Linear issue URLs as normalized task context.
 - Empty comments and known bot comments are filtered out.
 - The default issue context includes the last 10 human comments.
 
+## Repository Resolution
+
+Target repositories are resolved in this order:
+
+1. Explicit `--repo`
+2. GitHub issue URL inference
+3. Current directory `git remote get-url origin`
+
+If a GitHub issue URL points at a different repo than the current directory origin, Codex Cage fails unless `--repo` is passed explicitly. GitHub operations use HTTPS token auth with `GITHUB_TOKEN`; SSH remotes are normalized to `owner/repo` and converted to token-authenticated HTTPS clone URLs internally.
+
 ## Development
 
 ```bash

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -1,0 +1,175 @@
+import { execa } from "execa";
+import type { IssueContext } from "./issue.js";
+
+export type GithubRepo = {
+  owner: string;
+  name: string;
+  fullName: string;
+};
+
+export type RepoResolutionInput = {
+  explicitRepo?: string;
+  issue: IssueContext;
+  cwd?: string;
+  git?: GitRemoteReader;
+};
+
+export type RepoResolution = {
+  repo: GithubRepo;
+  source: "explicit" | "issue" | "cwd";
+};
+
+export type GitRemoteReader = {
+  getOriginUrl: (cwd: string) => Promise<string | null>;
+};
+
+export type AuthenticatedRepo = {
+  repo: GithubRepo;
+  cloneUrl: string;
+  redactedCloneUrl: string;
+};
+
+export const defaultGitRemoteReader: GitRemoteReader = {
+  async getOriginUrl(cwd: string): Promise<string | null> {
+    try {
+      const result = await execa("git", ["remote", "get-url", "origin"], { cwd });
+      return result.stdout.trim() === "" ? null : result.stdout.trim();
+    } catch {
+      return null;
+    }
+  },
+};
+
+export async function resolveTargetRepo(
+  input: RepoResolutionInput,
+): Promise<RepoResolution> {
+  const cwd = input.cwd ?? process.cwd();
+  const git = input.git ?? defaultGitRemoteReader;
+  const explicitRepo =
+    input.explicitRepo === undefined ? null : parseGithubRepo(input.explicitRepo);
+  const issueRepo =
+    input.issue.inferredRepo === null ? null : parseGithubRepo(input.issue.inferredRepo);
+  const cwdRepo = await readCwdRepo(git, cwd);
+
+  if (explicitRepo !== null) {
+    return { repo: explicitRepo, source: "explicit" };
+  }
+
+  if (issueRepo !== null) {
+    if (cwdRepo !== null && cwdRepo.fullName !== issueRepo.fullName) {
+      throw new Error(
+        `GitHub issue repo ${issueRepo.fullName} does not match current git origin ${cwdRepo.fullName}. Pass --repo to override.`,
+      );
+    }
+
+    return { repo: issueRepo, source: "issue" };
+  }
+
+  if (cwdRepo !== null) {
+    return { repo: cwdRepo, source: "cwd" };
+  }
+
+  throw new Error(
+    "Could not resolve target repo. Pass --repo or run inside a GitHub repo.",
+  );
+}
+
+export function parseGithubRepo(repo: string): GithubRepo {
+  const trimmed = repo.trim();
+  const normalized = normalizeGithubRemote(trimmed);
+  const [owner, name, ...rest] = normalized.split("/");
+
+  if (owner === undefined || name === undefined || rest.length > 0) {
+    throw new Error(`Invalid GitHub repository: ${repo}`);
+  }
+
+  return {
+    owner,
+    name,
+    fullName: `${owner}/${name}`,
+  };
+}
+
+export function createAuthenticatedRepo(
+  repo: GithubRepo,
+  githubToken: string | undefined,
+): AuthenticatedRepo {
+  if (githubToken === undefined || githubToken.trim() === "") {
+    throw new Error(
+      "GITHUB_TOKEN is required for GitHub clone, push, issue, and pull request operations.",
+    );
+  }
+
+  const encodedToken = encodeURIComponent(githubToken);
+
+  return {
+    repo,
+    cloneUrl: `https://x-access-token:${encodedToken}@github.com/${repo.fullName}.git`,
+    redactedCloneUrl: `https://x-access-token:[REDACTED]@github.com/${repo.fullName}.git`,
+  };
+}
+
+export function redactGithubToken(
+  value: string,
+  githubToken: string | undefined,
+): string {
+  if (githubToken === undefined || githubToken === "") {
+    return value;
+  }
+
+  return value.split(githubToken).join("[REDACTED]");
+}
+
+async function readCwdRepo(
+  git: GitRemoteReader,
+  cwd: string,
+): Promise<GithubRepo | null> {
+  const originUrl = await git.getOriginUrl(cwd);
+
+  if (originUrl === null) {
+    return null;
+  }
+
+  return parseGithubRepo(originUrl);
+}
+
+function normalizeGithubRemote(remote: string): string {
+  const withoutTrailingGit = remote.endsWith(".git") ? remote.slice(0, -4) : remote;
+  const sshMatch = withoutTrailingGit.match(/^git@github\.com:([^/]+)\/([^/]+)$/);
+
+  if (sshMatch !== null) {
+    return `${sshMatch[1]}/${sshMatch[2]}`;
+  }
+
+  const sshUrlMatch = withoutTrailingGit.match(
+    /^ssh:\/\/git@github\.com\/([^/]+)\/([^/]+)$/,
+  );
+
+  if (sshUrlMatch !== null) {
+    return `${sshUrlMatch[1]}/${sshUrlMatch[2]}`;
+  }
+
+  if (/^[^/:]+\/[^/:]+$/.test(withoutTrailingGit)) {
+    return withoutTrailingGit;
+  }
+
+  let url: URL;
+
+  try {
+    url = new URL(withoutTrailingGit);
+  } catch {
+    throw new Error(`Invalid GitHub repository: ${remote}`);
+  }
+
+  if (url.hostname !== "github.com") {
+    throw new Error(`Only github.com repositories are supported: ${remote}`);
+  }
+
+  const [owner, repo, ...rest] = url.pathname.split("/").filter(Boolean);
+
+  if (owner === undefined || repo === undefined || rest.length > 0) {
+    throw new Error(`Invalid GitHub repository: ${remote}`);
+  }
+
+  return `${owner}/${repo}`;
+}

--- a/test/repo.test.ts
+++ b/test/repo.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createAuthenticatedRepo,
+  parseGithubRepo,
+  redactGithubToken,
+  resolveTargetRepo,
+  type GitRemoteReader,
+} from "../src/repo.js";
+import type { IssueContext } from "../src/issue.js";
+
+function issueContext(inferredRepo: string | null): IssueContext {
+  return {
+    source: inferredRepo === null ? "linear" : "github",
+    url:
+      inferredRepo === null
+        ? "https://linear.app/acme/issue/ENG-123/fix-login"
+        : `https://github.com/${inferredRepo}/issues/123`,
+    identifier: inferredRepo === null ? "ENG-123" : "#123",
+    title: "Issue title",
+    body: "Issue body",
+    comments: [],
+    inferredRepo,
+  };
+}
+
+function gitOrigin(originUrl: string | null): GitRemoteReader {
+  return {
+    async getOriginUrl(): Promise<string | null> {
+      return originUrl;
+    },
+  };
+}
+
+test("parseGithubRepo normalizes owner/name strings", () => {
+  assert.deepEqual(parseGithubRepo("jhowliu/codex-cage"), {
+    owner: "jhowliu",
+    name: "codex-cage",
+    fullName: "jhowliu/codex-cage",
+  });
+});
+
+test("parseGithubRepo normalizes GitHub HTTPS remotes", () => {
+  assert.equal(
+    parseGithubRepo("https://github.com/jhowliu/codex-cage.git").fullName,
+    "jhowliu/codex-cage",
+  );
+});
+
+test("parseGithubRepo normalizes GitHub SSH remotes", () => {
+  assert.equal(
+    parseGithubRepo("git@github.com:jhowliu/codex-cage.git").fullName,
+    "jhowliu/codex-cage",
+  );
+});
+
+test("resolveTargetRepo prefers explicit repo", async () => {
+  const result = await resolveTargetRepo({
+    explicitRepo: "jhowliu/override",
+    issue: issueContext("jhowliu/codex-cage"),
+    git: gitOrigin("https://github.com/jhowliu/local.git"),
+  });
+
+  assert.equal(result.source, "explicit");
+  assert.equal(result.repo.fullName, "jhowliu/override");
+});
+
+test("resolveTargetRepo uses GitHub issue inferred repo", async () => {
+  const result = await resolveTargetRepo({
+    issue: issueContext("jhowliu/codex-cage"),
+    git: gitOrigin("https://github.com/jhowliu/codex-cage.git"),
+  });
+
+  assert.equal(result.source, "issue");
+  assert.equal(result.repo.fullName, "jhowliu/codex-cage");
+});
+
+test("resolveTargetRepo fails on GitHub issue and cwd origin mismatch", async () => {
+  await assert.rejects(
+    () =>
+      resolveTargetRepo({
+        issue: issueContext("jhowliu/codex-cage"),
+        git: gitOrigin("https://github.com/jhowliu/other.git"),
+      }),
+    /does not match current git origin/,
+  );
+});
+
+test("resolveTargetRepo uses cwd origin for Linear issue", async () => {
+  const result = await resolveTargetRepo({
+    issue: issueContext(null),
+    git: gitOrigin("git@github.com:jhowliu/codex-cage.git"),
+  });
+
+  assert.equal(result.source, "cwd");
+  assert.equal(result.repo.fullName, "jhowliu/codex-cage");
+});
+
+test("resolveTargetRepo fails when no repo source exists", async () => {
+  await assert.rejects(
+    () =>
+      resolveTargetRepo({
+        issue: issueContext(null),
+        git: gitOrigin(null),
+      }),
+    /Could not resolve target repo/,
+  );
+});
+
+test("createAuthenticatedRepo uses token HTTPS clone URL and redacted display URL", () => {
+  const authenticatedRepo = createAuthenticatedRepo(
+    parseGithubRepo("jhowliu/codex-cage"),
+    "ghp_secret",
+  );
+
+  assert.equal(
+    authenticatedRepo.cloneUrl,
+    "https://x-access-token:ghp_secret@github.com/jhowliu/codex-cage.git",
+  );
+  assert.equal(
+    authenticatedRepo.redactedCloneUrl,
+    "https://x-access-token:[REDACTED]@github.com/jhowliu/codex-cage.git",
+  );
+});
+
+test("createAuthenticatedRepo requires GITHUB_TOKEN", () => {
+  assert.throws(
+    () => createAuthenticatedRepo(parseGithubRepo("jhowliu/codex-cage"), ""),
+    /GITHUB_TOKEN is required/,
+  );
+});
+
+test("redactGithubToken removes token values from logs", () => {
+  assert.equal(
+    redactGithubToken("push https://x-access-token:ghp_secret@github.com", "ghp_secret"),
+    "push https://x-access-token:[REDACTED]@github.com",
+  );
+});


### PR DESCRIPTION
## Summary
- Add GitHub repo normalization for owner/name, HTTPS remotes, and SSH remotes.
- Resolve target repos by priority: explicit repo, GitHub issue inference, then current git origin.
- Fail when a GitHub issue repo conflicts with cwd origin unless `--repo` is explicit.
- Build token-authenticated HTTPS clone URLs from `GITHUB_TOKEN` with redacted display URLs.
- Document repo resolution and token-auth behavior.

## Verification
- `npm run typecheck`
- `npm test`
- `npm run format`
- `npm --cache /tmp/codex-cage-npm-cache exec -- codex-cage --help`
- `npm --cache /tmp/codex-cage-npm-cache pack --dry-run`

Closes #6