### PR TITLE
Add Docker sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ Target repositories are resolved in this order:
 
 If a GitHub issue URL points at a different repo than the current directory origin, Codex Cage fails unless `--repo` is passed explicitly. GitHub operations use HTTPS token auth with `GITHUB_TOKEN`; SSH remotes are normalized to `owner/repo` and converted to token-authenticated HTTPS clone URLs internally.
 
+## Docker Sandbox
+
+Codex Cage prepares disposable Docker resources per run:
+
+- A labeled Docker volume for `/workspace`
+- A labeled Docker network for run-local connectivity
+- An agent container using the pinned default image `codex-cage/base:0.1.0`
+
+The sandbox runs as the non-root `agent` user, clones the target repo into the volume, and does not bind mount the host working tree, Docker socket, SSH config, GitHub CLI config, or host ports.
+
 ## Development
 
 ```bash

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,0 +1,181 @@
+import { execa } from "execa";
+
+export type DockerRunner = {
+  run: (args: string[]) => Promise<void>;
+};
+
+export type DockerSandboxOptions = {
+  runId: string;
+  cloneUrl: string;
+  image?: string;
+  workspacePath?: string;
+  labels?: Record<string, string>;
+  env?: Record<string, string>;
+};
+
+export type DockerSandbox = {
+  runId: string;
+  image: string;
+  volumeName: string;
+  networkName: string;
+  workspacePath: string;
+  create(): Promise<void>;
+  cloneRepository(): Promise<void>;
+  runCommand(command: string): Promise<void>;
+  cleanup(): Promise<void>;
+};
+
+export type DockerResourceNames = {
+  volumeName: string;
+  networkName: string;
+};
+
+export const defaultSandboxImage = "codex-cage/base:0.1.0";
+export const defaultWorkspacePath = "/workspace";
+
+const runIdLabelName = "codex-cage.run_id";
+
+export const execaDockerRunner: DockerRunner = {
+  async run(args: string[]): Promise<void> {
+    await execa("docker", args, { stdio: "inherit" });
+  },
+};
+
+export function createDockerSandbox(
+  options: DockerSandboxOptions,
+  runner: DockerRunner = execaDockerRunner,
+): DockerSandbox {
+  const image = options.image ?? defaultSandboxImage;
+  const workspacePath = options.workspacePath ?? defaultWorkspacePath;
+  const { volumeName, networkName } = dockerResourceNames(options.runId);
+  const labels = {
+    [runIdLabelName]: options.runId,
+    ...options.labels,
+  };
+
+  return {
+    runId: options.runId,
+    image,
+    volumeName,
+    networkName,
+    workspacePath,
+    async create(): Promise<void> {
+      await runner.run(volumeCreateArgs(volumeName, labels));
+      await runner.run(networkCreateArgs(networkName, labels));
+    },
+    async cloneRepository(): Promise<void> {
+      await runner.run(
+        dockerRunArgs({
+          image,
+          networkName,
+          volumeName,
+          workspacePath,
+          labels,
+          env: options.env ?? {},
+          command: `git clone ${shellQuote(options.cloneUrl)} .`,
+        }),
+      );
+    },
+    async runCommand(command: string): Promise<void> {
+      await runner.run(
+        dockerRunArgs({
+          image,
+          networkName,
+          volumeName,
+          workspacePath,
+          labels,
+          env: options.env ?? {},
+          command,
+        }),
+      );
+    },
+    async cleanup(): Promise<void> {
+      await cleanupDockerResources({ volumeName, networkName }, runner);
+    },
+  };
+}
+
+export async function cleanupDockerResources(
+  resources: DockerResourceNames,
+  runner: DockerRunner = execaDockerRunner,
+): Promise<void> {
+  await runner.run(["network", "rm", resources.networkName]);
+  await runner.run(["volume", "rm", resources.volumeName]);
+}
+
+export function dockerResourceNames(runId: string): DockerResourceNames {
+  const safeRunId = runId
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (safeRunId === "") {
+    throw new Error("Run id must contain at least one Docker-safe character.");
+  }
+
+  return {
+    volumeName: `codex-cage-${safeRunId}-workspace`,
+    networkName: `codex-cage-${safeRunId}`,
+  };
+}
+
+export function volumeCreateArgs(
+  volumeName: string,
+  labels: Record<string, string>,
+): string[] {
+  return ["volume", "create", ...labelArgs(labels), volumeName];
+}
+
+export function networkCreateArgs(
+  networkName: string,
+  labels: Record<string, string>,
+): string[] {
+  return ["network", "create", ...labelArgs(labels), networkName];
+}
+
+type DockerRunArgsInput = {
+  image: string;
+  networkName: string;
+  volumeName: string;
+  workspacePath: string;
+  labels: Record<string, string>;
+  env: Record<string, string>;
+  command: string;
+};
+
+export function dockerRunArgs(input: DockerRunArgsInput): string[] {
+  return [
+    "run",
+    "--rm",
+    ...labelArgs(input.labels),
+    "--network",
+    input.networkName,
+    "--mount",
+    `type=volume,source=${input.volumeName},target=${input.workspacePath}`,
+    "--workdir",
+    input.workspacePath,
+    "--user",
+    "agent",
+    ...envArgs(input.env),
+    input.image,
+    "sh",
+    "-lc",
+    input.command,
+  ];
+}
+
+function labelArgs(labels: Record<string, string>): string[] {
+  return Object.entries({ "codex-cage.managed": "true", ...labels }).flatMap(
+    ([key, value]) => ["--label", `${key}=${value}`],
+  );
+}
+
+function envArgs(env: Record<string, string>): string[] {
+  return Object.keys(env)
+    .sort()
+    .flatMap((name) => ["--env", name]);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/test/docker.test.ts
+++ b/test/docker.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createDockerSandbox,
+  dockerResourceNames,
+  dockerRunArgs,
+  networkCreateArgs,
+  volumeCreateArgs,
+  type DockerRunner,
+} from "../src/docker.js";
+
+function recordingRunner(): DockerRunner & { calls: string[][] } {
+  const calls: string[][] = [];
+
+  return {
+    calls,
+    async run(args: string[]): Promise<void> {
+      calls.push(args);
+    },
+  };
+}
+
+test("dockerResourceNames creates stable Docker-safe resource names", () => {
+  assert.deepEqual(dockerResourceNames("RUN 123/ABC"), {
+    volumeName: "codex-cage-run-123-abc-workspace",
+    networkName: "codex-cage-run-123-abc",
+  });
+});
+
+test("volume and network resources carry managed labels", () => {
+  assert.deepEqual(volumeCreateArgs("workspace", { "codex-cage.run_id": "run-1" }), [
+    "volume",
+    "create",
+    "--label",
+    "codex-cage.managed=true",
+    "--label",
+    "codex-cage.run_id=run-1",
+    "workspace",
+  ]);
+  assert.deepEqual(networkCreateArgs("network", { "codex-cage.run_id": "run-1" }), [
+    "network",
+    "create",
+    "--label",
+    "codex-cage.managed=true",
+    "--label",
+    "codex-cage.run_id=run-1",
+    "network",
+  ]);
+});
+
+test("dockerRunArgs uses volume workspace and avoids host-sensitive mounts", () => {
+  const args = dockerRunArgs({
+    image: "codex-cage/base:0.1.0",
+    networkName: "codex-cage-run-1",
+    volumeName: "codex-cage-run-1-workspace",
+    workspacePath: "/workspace",
+    labels: { "codex-cage.run_id": "run-1" },
+    env: { GITHUB_TOKEN: "secret", OPENAI_API_KEY: "secret" },
+    command: "npm test",
+  });
+  const joinedArgs = args.join(" ");
+
+  assert.equal(args.includes("--user"), true);
+  assert.equal(args.at(args.indexOf("--user") + 1), "agent");
+  assert.equal(args.includes("--publish"), false);
+  assert.equal(args.includes("-p"), false);
+  assert.equal(joinedArgs.includes("/var/run/docker.sock"), false);
+  assert.equal(joinedArgs.includes(".ssh"), false);
+  assert.equal(joinedArgs.includes(".config/gh"), false);
+  assert.equal(joinedArgs.includes("type=bind"), false);
+  assert.equal(
+    joinedArgs.includes(
+      "--mount type=volume,source=codex-cage-run-1-workspace,target=/workspace",
+    ),
+    true,
+  );
+  assert.equal(joinedArgs.includes("secret"), false);
+  assert.deepEqual(args.slice(-3), ["sh", "-lc", "npm test"]);
+});
+
+test("createDockerSandbox creates resources, clones into volume, runs commands, and cleans up", async () => {
+  const runner = recordingRunner();
+  const sandbox = createDockerSandbox(
+    {
+      runId: "run-1",
+      cloneUrl: "https://x-access-token:token@github.com/jhowliu/codex-cage.git",
+      env: {
+        GITHUB_TOKEN: "token",
+      },
+    },
+    runner,
+  );
+
+  await sandbox.create();
+  await sandbox.cloneRepository();
+  await sandbox.runCommand("npm test");
+  await sandbox.cleanup();
+
+  assert.equal(sandbox.volumeName, "codex-cage-run-1-workspace");
+  assert.equal(sandbox.networkName, "codex-cage-run-1");
+  assert.equal(runner.calls.length, 6);
+  assert.deepEqual(runner.calls[0]?.slice(0, 2), ["volume", "create"]);
+  assert.deepEqual(runner.calls[1]?.slice(0, 2), ["network", "create"]);
+  assert.equal(
+    runner.calls[2]?.some((arg) => arg.includes("git clone")),
+    true,
+  );
+  assert.equal(runner.calls[3]?.at(-1), "npm test");
+  assert.deepEqual(runner.calls[4], ["network", "rm", "codex-cage-run-1"]);
+  assert.deepEqual(runner.calls[5], ["volume", "rm", "codex-cage-run-1-workspace"]);
+});


### PR DESCRIPTION
## Summary
- Add a Docker sandbox module for per-run labeled volume and network resources.
- Clone target repos into a disposable Docker volume instead of mounting the host working tree.
- Run sandbox commands as the non-root `agent` user with no host bind mounts, Docker socket, SSH config, gh config, or published ports.
- Add cleanup helpers for managed volume/network resources.
- Document sandbox boundaries and add unit tests for Docker command construction.

## Verification
- `npm run typecheck`
- `npm test`
- `npm run format`
- `npm --cache /tmp/codex-cage-npm-cache exec -- codex-cage --help`
- `npm --cache /tmp/codex-cage-npm-cache pack --dry-run`

Closes #7