### PR TITLE
Support Compose services

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ Codex Cage prepares disposable Docker resources per run:
 
 The sandbox runs as the non-root `agent` user, clones the target repo into the volume, and does not bind mount the host working tree, Docker socket, SSH config, GitHub CLI config, or host ports.
 
+## Compose Services
+
+Target repos can configure Docker Compose services in `.codex-cage.yml`:
+
+```yaml
+services:
+  compose: docker-compose.yml
+  ready:
+    - pg_isready -h db -U postgres
+```
+
+Codex Cage uses a per-run Compose project name, starts services with `docker compose up -d`, attaches the agent container to the Compose network, runs readiness checks from an ephemeral container on that network, and tears services down with `docker compose down -v`.
+
 ## Development
 
 ```bash

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,0 +1,133 @@
+import { execa } from "execa";
+import { defaultSandboxImage, type DockerRunner } from "./docker.js";
+
+export type ComposeServicesConfig = {
+  compose: string | null;
+  ready: string[];
+};
+
+export type ComposeProjectOptions = {
+  runId: string;
+  composeFile: string;
+  projectDirectory: string;
+  readyCommands?: string[];
+  runner?: ComposeRunner;
+  dockerRunner?: DockerRunner;
+  readyImage?: string;
+};
+
+export type ComposeProject = {
+  projectName: string;
+  networkName: string;
+  composeFile: string;
+  projectDirectory: string;
+  up(): Promise<void>;
+  waitUntilReady(): Promise<void>;
+  down(): Promise<void>;
+};
+
+export type ComposeRunner = {
+  run: (args: string[]) => Promise<void>;
+};
+
+export const execaComposeRunner: ComposeRunner = {
+  async run(args: string[]): Promise<void> {
+    await execa("docker", ["compose", ...args], { stdio: "inherit" });
+  },
+};
+
+export function createComposeProject(options: ComposeProjectOptions): ComposeProject {
+  const runner = options.runner ?? execaComposeRunner;
+  const dockerRunner = options.dockerRunner ?? {
+    async run(args: string[]): Promise<void> {
+      await execa("docker", args, { stdio: "inherit" });
+    },
+  };
+  const projectName = composeProjectName(options.runId);
+  const networkName = `${projectName}_default`;
+
+  return {
+    projectName,
+    networkName,
+    composeFile: options.composeFile,
+    projectDirectory: options.projectDirectory,
+    async up(): Promise<void> {
+      await runner.run(composeBaseArgs(options).concat(["up", "-d"]));
+    },
+    async waitUntilReady(): Promise<void> {
+      for (const command of options.readyCommands ?? []) {
+        await dockerRunner.run(
+          readyCommandRunArgs({
+            image: options.readyImage ?? defaultSandboxImage,
+            networkName,
+            runId: options.runId,
+            command,
+          }),
+        );
+      }
+    },
+    async down(): Promise<void> {
+      await runner.run(composeBaseArgs(options).concat(["down", "-v"]));
+    },
+  };
+}
+
+export function composeProjectName(runId: string): string {
+  const safeRunId = runId
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (safeRunId === "") {
+    throw new Error("Run id must contain at least one Compose-safe character.");
+  }
+
+  return `codex-cage-${safeRunId}`;
+}
+
+export function composeBaseArgs(options: {
+  runId: string;
+  composeFile: string;
+  projectDirectory: string;
+}): string[] {
+  return [
+    "--project-name",
+    composeProjectName(options.runId),
+    "--project-directory",
+    options.projectDirectory,
+    "-f",
+    options.composeFile,
+  ];
+}
+
+export function hasComposeServices(config: ComposeServicesConfig): boolean {
+  return config.compose !== null;
+}
+
+type ReadyCommandRunArgsInput = {
+  image: string;
+  networkName: string;
+  runId: string;
+  command: string;
+};
+
+export function readyCommandRunArgs(input: ReadyCommandRunArgsInput): string[] {
+  return [
+    "run",
+    "--rm",
+    "--label",
+    "codex-cage.managed=true",
+    "--label",
+    `codex-cage.run_id=${input.runId}`,
+    "--label",
+    "codex-cage.phase=ready",
+    "--network",
+    input.networkName,
+    "--user",
+    "agent",
+    input.image,
+    "sh",
+    "-lc",
+    input.command,
+  ];
+}

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -9,6 +9,7 @@ export type DockerSandboxOptions = {
   cloneUrl: string;
   image?: string;
   workspacePath?: string;
+  serviceNetworkName?: string;
   labels?: Record<string, string>;
   env?: Record<string, string>;
 };
@@ -18,6 +19,7 @@ export type DockerSandbox = {
   image: string;
   volumeName: string;
   networkName: string;
+  ownedNetworkName: string | null;
   workspacePath: string;
   create(): Promise<void>;
   cloneRepository(): Promise<void>;
@@ -48,6 +50,8 @@ export function createDockerSandbox(
   const image = options.image ?? defaultSandboxImage;
   const workspacePath = options.workspacePath ?? defaultWorkspacePath;
   const { volumeName, networkName } = dockerResourceNames(options.runId);
+  const ownedNetworkName = options.serviceNetworkName === undefined ? networkName : null;
+  const agentNetworkName = options.serviceNetworkName ?? networkName;
   const labels = {
     [runIdLabelName]: options.runId,
     ...options.labels,
@@ -57,17 +61,20 @@ export function createDockerSandbox(
     runId: options.runId,
     image,
     volumeName,
-    networkName,
+    networkName: agentNetworkName,
+    ownedNetworkName,
     workspacePath,
     async create(): Promise<void> {
       await runner.run(volumeCreateArgs(volumeName, labels));
-      await runner.run(networkCreateArgs(networkName, labels));
+      if (ownedNetworkName !== null) {
+        await runner.run(networkCreateArgs(ownedNetworkName, labels));
+      }
     },
     async cloneRepository(): Promise<void> {
       await runner.run(
         dockerRunArgs({
           image,
-          networkName,
+          networkName: agentNetworkName,
           volumeName,
           workspacePath,
           labels,
@@ -80,7 +87,7 @@ export function createDockerSandbox(
       await runner.run(
         dockerRunArgs({
           image,
-          networkName,
+          networkName: agentNetworkName,
           volumeName,
           workspacePath,
           labels,
@@ -90,7 +97,10 @@ export function createDockerSandbox(
       );
     },
     async cleanup(): Promise<void> {
-      await cleanupDockerResources({ volumeName, networkName }, runner);
+      if (ownedNetworkName !== null) {
+        await runner.run(["network", "rm", ownedNetworkName]);
+      }
+      await runner.run(["volume", "rm", volumeName]);
     },
   };
 }

--- a/test/compose.test.ts
+++ b/test/compose.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  composeBaseArgs,
+  composeProjectName,
+  createComposeProject,
+  hasComposeServices,
+  readyCommandRunArgs,
+  type ComposeRunner,
+} from "../src/compose.js";
+import type { DockerRunner } from "../src/docker.js";
+
+function recordingComposeRunner(): ComposeRunner & { calls: string[][] } {
+  const calls: string[][] = [];
+
+  return {
+    calls,
+    async run(args: string[]): Promise<void> {
+      calls.push(args);
+    },
+  };
+}
+
+function recordingDockerRunner(): DockerRunner & { calls: string[][] } {
+  const calls: string[][] = [];
+
+  return {
+    calls,
+    async run(args: string[]): Promise<void> {
+      calls.push(args);
+    },
+  };
+}
+
+test("composeProjectName creates stable per-run project names", () => {
+  assert.equal(composeProjectName("RUN 123/ABC"), "codex-cage-run-123-abc");
+});
+
+test("composeBaseArgs scopes compose to project name and project directory", () => {
+  assert.deepEqual(
+    composeBaseArgs({
+      runId: "run-1",
+      composeFile: "docker-compose.yml",
+      projectDirectory: "/workspace",
+    }),
+    [
+      "--project-name",
+      "codex-cage-run-1",
+      "--project-directory",
+      "/workspace",
+      "-f",
+      "docker-compose.yml",
+    ],
+  );
+});
+
+test("hasComposeServices reports whether compose is configured", () => {
+  assert.equal(hasComposeServices({ compose: null, ready: [] }), false);
+  assert.equal(hasComposeServices({ compose: "docker-compose.yml", ready: [] }), true);
+});
+
+test("compose project starts and tears down services with volumes", async () => {
+  const runner = recordingComposeRunner();
+  const project = createComposeProject({
+    runId: "run-1",
+    composeFile: "docker-compose.yml",
+    projectDirectory: "/workspace",
+    runner,
+  });
+
+  await project.up();
+  await project.down();
+
+  assert.equal(project.projectName, "codex-cage-run-1");
+  assert.equal(project.networkName, "codex-cage-run-1_default");
+  assert.deepEqual(runner.calls, [
+    [
+      "--project-name",
+      "codex-cage-run-1",
+      "--project-directory",
+      "/workspace",
+      "-f",
+      "docker-compose.yml",
+      "up",
+      "-d",
+    ],
+    [
+      "--project-name",
+      "codex-cage-run-1",
+      "--project-directory",
+      "/workspace",
+      "-f",
+      "docker-compose.yml",
+      "down",
+      "-v",
+    ],
+  ]);
+});
+
+test("compose readiness commands run on compose network without Docker socket or host ports", async () => {
+  const dockerRunner = recordingDockerRunner();
+  const project = createComposeProject({
+    runId: "run-1",
+    composeFile: "docker-compose.yml",
+    projectDirectory: "/workspace",
+    readyCommands: ["pg_isready -h db -U postgres"],
+    dockerRunner,
+  });
+
+  await project.waitUntilReady();
+
+  const readyArgs = dockerRunner.calls[0] ?? [];
+  const joinedArgs = readyArgs.join(" ");
+
+  assert.equal(readyArgs.includes("--network"), true);
+  assert.equal(
+    readyArgs.at(readyArgs.indexOf("--network") + 1),
+    "codex-cage-run-1_default",
+  );
+  assert.equal(readyArgs.includes("--publish"), false);
+  assert.equal(readyArgs.includes("-p"), false);
+  assert.equal(joinedArgs.includes("/var/run/docker.sock"), false);
+  assert.equal(joinedArgs.includes("type=bind"), false);
+  assert.equal(joinedArgs.includes("type=volume"), false);
+  assert.deepEqual(readyArgs.slice(-3), ["sh", "-lc", "pg_isready -h db -U postgres"]);
+});
+
+test("readyCommandRunArgs is explicit about the no-workspace readiness container", () => {
+  const args = readyCommandRunArgs({
+    image: "codex-cage/base:0.1.0",
+    networkName: "codex-cage-run-1_default",
+    runId: "run-1",
+    command: "redis-cli -h redis ping",
+  });
+
+  assert.equal(args.includes("--mount"), false);
+  assert.equal(args.includes("--workdir"), false);
+  assert.equal(args.at(args.indexOf("--user") + 1), "agent");
+  assert.deepEqual(args.slice(-3), ["sh", "-lc", "redis-cli -h redis ping"]);
+});

--- a/test/docker.test.ts
+++ b/test/docker.test.ts
@@ -98,6 +98,7 @@ test("createDockerSandbox creates resources, clones into volume, runs commands, 
 
   assert.equal(sandbox.volumeName, "codex-cage-run-1-workspace");
   assert.equal(sandbox.networkName, "codex-cage-run-1");
+  assert.equal(sandbox.ownedNetworkName, "codex-cage-run-1");
   assert.equal(runner.calls.length, 6);
   assert.deepEqual(runner.calls[0]?.slice(0, 2), ["volume", "create"]);
   assert.deepEqual(runner.calls[1]?.slice(0, 2), ["network", "create"]);
@@ -108,4 +109,40 @@ test("createDockerSandbox creates resources, clones into volume, runs commands, 
   assert.equal(runner.calls[3]?.at(-1), "npm test");
   assert.deepEqual(runner.calls[4], ["network", "rm", "codex-cage-run-1"]);
   assert.deepEqual(runner.calls[5], ["volume", "rm", "codex-cage-run-1-workspace"]);
+});
+
+test("createDockerSandbox can attach agent commands to an externally managed service network", async () => {
+  const runner = recordingRunner();
+  const sandbox = createDockerSandbox(
+    {
+      runId: "run-1",
+      cloneUrl: "https://github.com/jhowliu/codex-cage.git",
+      serviceNetworkName: "codex-cage-run-1_default",
+    },
+    runner,
+  );
+
+  await sandbox.create();
+  await sandbox.cloneRepository();
+  await sandbox.runCommand("npm test");
+  await sandbox.cleanup();
+
+  assert.equal(sandbox.networkName, "codex-cage-run-1_default");
+  assert.equal(sandbox.ownedNetworkName, null);
+  assert.equal(runner.calls.length, 4);
+  assert.deepEqual(runner.calls[0]?.slice(0, 2), ["volume", "create"]);
+  assert.equal(
+    runner.calls.some((call) => call[0] === "network"),
+    false,
+  );
+  assert.equal(
+    runner.calls[1]?.at((runner.calls[1] ?? []).indexOf("--network") + 1),
+    "codex-cage-run-1_default",
+  );
+  assert.equal(
+    runner.calls[2]?.at((runner.calls[2] ?? []).indexOf("--network") + 1),
+    "codex-cage-run-1_default",
+  );
+  assert.equal(runner.calls.flat().includes("/var/run/docker.sock"), false);
+  assert.deepEqual(runner.calls[3], ["volume", "rm", "codex-cage-run-1-workspace"]);
 });


### PR DESCRIPTION
## Summary
- Add Compose project orchestration helpers for per-run project names, up/down lifecycle, and readiness checks on the Compose network.
- Let Docker sandbox commands attach to an externally managed service network without giving the agent Docker control.
- Document Compose service configuration in README.

## Validation
- npm run typecheck
- npm test
- npm run format
- npm --cache /tmp/codex-cage-npm-cache exec -- codex-cage --help
- npm --cache /tmp/codex-cage-npm-cache pack --dry-run

Closes #8