### PR TITLE
Add secret guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ services:
 
 Codex Cage uses a per-run Compose project name, starts services with `docker compose up -d`, attaches the agent container to the Compose network, runs readiness checks from an ephemeral container on that network, and tears services down with `docker compose down -v`.
 
+## Secret Guards
+
+Local secrets live in `.codex-cage.env`, which is parsed by the orchestrator and passed to Docker as process environment, not mounted into the container or written into command arguments. Known secret values are redacted from logs.
+
+Guard scanning checks diffs for injected secret values, high-confidence token patterns, private key material, and sensitive auth files such as `.env`, `.codex-cage.env`, `.npmrc`, `.ssh/*`, `.config/gh/*`, and `.aws/*`. Sample env files like `.env.example`, `.env.sample`, and `.env.template` are allowed, but their added content is still scanned for secret-looking values.
+
 ## Development
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "zod": "^3.24.2"
       },
       "bin": {
-        "codex-cage": "dist/cli.js"
+        "codex-cage": "dist/src/cli.js"
       },
       "devDependencies": {
         "@types/node": "^22.13.1",

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,7 +1,11 @@
 import { execa } from "execa";
 
 export type DockerRunner = {
-  run: (args: string[]) => Promise<void>;
+  run: (args: string[], options?: DockerRunOptions) => Promise<void>;
+};
+
+export type DockerRunOptions = {
+  env?: Record<string, string>;
 };
 
 export type DockerSandboxOptions = {
@@ -38,8 +42,13 @@ export const defaultWorkspacePath = "/workspace";
 const runIdLabelName = "codex-cage.run_id";
 
 export const execaDockerRunner: DockerRunner = {
-  async run(args: string[]): Promise<void> {
-    await execa("docker", args, { stdio: "inherit" });
+  async run(args: string[], options: DockerRunOptions = {}): Promise<void> {
+    if (options.env === undefined) {
+      await execa("docker", args, { stdio: "inherit" });
+      return;
+    }
+
+    await execa("docker", args, { env: options.env, stdio: "inherit" });
   },
 };
 
@@ -81,6 +90,7 @@ export function createDockerSandbox(
           env: options.env ?? {},
           command: `git clone ${shellQuote(options.cloneUrl)} .`,
         }),
+        { env: options.env ?? {} },
       );
     },
     async runCommand(command: string): Promise<void> {
@@ -94,6 +104,7 @@ export function createDockerSandbox(
           env: options.env ?? {},
           command,
         }),
+        { env: options.env ?? {} },
       );
     },
     async cleanup(): Promise<void> {

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -1,0 +1,355 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export type GuardViolation =
+  | {
+      code: "sensitive_file";
+      path: string;
+      message: string;
+    }
+  | {
+      code: "injected_secret";
+      path: string;
+      line: number;
+      secretName: string;
+      message: string;
+    }
+  | {
+      code: "token_pattern";
+      path: string;
+      line: number;
+      pattern: string;
+      message: string;
+    }
+  | {
+      code: "private_key";
+      path: string;
+      line: number;
+      message: string;
+    };
+
+export type DiffGuardOptions = {
+  injectedSecrets?: Record<string, string>;
+};
+
+export type GuardAttemptDecision =
+  | { action: "retry"; nextAttempt: number }
+  | { action: "fail"; attempts: number };
+
+export class GuardViolationError extends Error {
+  readonly violations: GuardViolation[];
+
+  constructor(violations: GuardViolation[]) {
+    super(formatGuardViolations(violations));
+    this.name = "GuardViolationError";
+    this.violations = violations;
+  }
+}
+
+const envAssignmentPattern = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/;
+const minSecretLength = 4;
+const envFilePath = ".codex-cage.env";
+
+const tokenPatterns = [
+  {
+    name: "github_token",
+    pattern: /(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,}/,
+  },
+  {
+    name: "openai_api_key",
+    pattern: /sk-[A-Za-z0-9_-]{20,}/,
+  },
+  {
+    name: "aws_access_key_id",
+    pattern: /AKIA[0-9A-Z]{16}/,
+  },
+  {
+    name: "slack_token",
+    pattern: /xox[baprs]-[A-Za-z0-9-]{20,}/,
+  },
+] as const;
+
+export async function readCodexCageEnv(
+  cwd: string,
+  relativePath = envFilePath,
+): Promise<Record<string, string>> {
+  const path = join(cwd, relativePath);
+
+  try {
+    return parseEnvFile(await readFile(path, "utf8"));
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return {};
+    }
+
+    throw error;
+  }
+}
+
+export function parseEnvFile(content: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  const lines = content.split(/\r?\n/);
+
+  for (const [index, rawLine] of lines.entries()) {
+    const trimmedLine = rawLine.trim();
+
+    if (trimmedLine === "" || trimmedLine.startsWith("#")) {
+      continue;
+    }
+
+    const match = trimmedLine.match(envAssignmentPattern);
+
+    if (match === null) {
+      throw new Error(`Invalid env assignment on line ${index + 1}.`);
+    }
+
+    const name = match[1];
+    const rawValue = match[2];
+
+    if (name === undefined || rawValue === undefined) {
+      throw new Error(`Invalid env assignment on line ${index + 1}.`);
+    }
+
+    env[name] = unquoteEnvValue(rawValue.trim());
+  }
+
+  return env;
+}
+
+export function createSecretRedactor(
+  secrets: Record<string, string>,
+): (input: string) => string {
+  const secretEntries = Object.entries(secrets).filter(([, value]) =>
+    isScannableSecret(value),
+  );
+
+  return (input: string): string => {
+    let redacted = input;
+
+    for (const [name, value] of secretEntries) {
+      redacted = redacted.replaceAll(value, `[REDACTED:${name}]`);
+    }
+
+    return redacted;
+  };
+}
+
+export function scanDiffForGuardViolations(
+  diff: string,
+  options: DiffGuardOptions = {},
+): GuardViolation[] {
+  const violations: GuardViolation[] = [];
+  const injectedSecrets = Object.entries(options.injectedSecrets ?? {}).filter(
+    ([, value]) => isScannableSecret(value),
+  );
+  let currentPath: string | null = null;
+  let newLineNumber = 0;
+  const reportedSensitivePaths = new Set<string>();
+
+  for (const line of diff.split(/\r?\n/)) {
+    const diffPath = parseDiffPath(line);
+
+    if (diffPath !== null) {
+      currentPath = diffPath;
+      newLineNumber = 0;
+
+      if (isSensitiveFilePath(currentPath) && !reportedSensitivePaths.has(currentPath)) {
+        reportedSensitivePaths.add(currentPath);
+        violations.push({
+          code: "sensitive_file",
+          path: currentPath,
+          message: `Sensitive file "${currentPath}" cannot be changed.`,
+        });
+      }
+
+      continue;
+    }
+
+    const hunkStart = parseHunkNewStart(line);
+
+    if (hunkStart !== null) {
+      newLineNumber = hunkStart;
+      continue;
+    }
+
+    if (currentPath === null || line.startsWith("---") || line.startsWith("+++")) {
+      continue;
+    }
+
+    if (line.startsWith("+")) {
+      const addedContent = line.slice(1);
+      violations.push(
+        ...scanAddedLine({
+          path: currentPath,
+          line: newLineNumber,
+          content: addedContent,
+          injectedSecrets,
+        }),
+      );
+      newLineNumber += 1;
+      continue;
+    }
+
+    if (!line.startsWith("-")) {
+      newLineNumber += 1;
+    }
+  }
+
+  return violations;
+}
+
+export function assertNoGuardViolations(violations: GuardViolation[]): void {
+  if (violations.length > 0) {
+    throw new GuardViolationError(violations);
+  }
+}
+
+export function formatGuardViolations(violations: GuardViolation[]): string {
+  if (violations.length === 0) {
+    return "No guard violations.";
+  }
+
+  return violations
+    .map((violation) => {
+      const location =
+        "line" in violation ? `${violation.path}:${violation.line}` : violation.path;
+
+      return `${location} [${violation.code}] ${violation.message}`;
+    })
+    .join("\n");
+}
+
+export function isSensitiveFilePath(path: string): boolean {
+  const normalized = path.replaceAll("\\", "/");
+  const basename = normalized.split("/").at(-1) ?? normalized;
+
+  if (isSampleEnvFilePath(normalized)) {
+    return false;
+  }
+
+  return (
+    basename === ".env" ||
+    basename === ".codex-cage.env" ||
+    basename === ".npmrc" ||
+    basename === ".pypirc" ||
+    basename === ".netrc" ||
+    basename === "credentials" ||
+    normalized.includes("/.ssh/") ||
+    normalized.startsWith(".ssh/") ||
+    normalized.includes("/.config/gh/") ||
+    normalized.startsWith(".config/gh/") ||
+    normalized.includes("/.aws/") ||
+    normalized.startsWith(".aws/")
+  );
+}
+
+export function guardAttemptDecision(input: {
+  attempt: number;
+  maxAttempts: number;
+}): GuardAttemptDecision {
+  const attempts = input.attempt + 1;
+
+  if (attempts > input.maxAttempts) {
+    return { action: "fail", attempts };
+  }
+
+  return { action: "retry", nextAttempt: attempts };
+}
+
+function scanAddedLine(input: {
+  path: string;
+  line: number;
+  content: string;
+  injectedSecrets: Array<[string, string]>;
+}): GuardViolation[] {
+  const violations: GuardViolation[] = [];
+
+  for (const [secretName, value] of input.injectedSecrets) {
+    if (input.content.includes(value)) {
+      violations.push({
+        code: "injected_secret",
+        path: input.path,
+        line: input.line,
+        secretName,
+        message: `Injected secret "${secretName}" appears in the diff.`,
+      });
+    }
+  }
+
+  for (const tokenPattern of tokenPatterns) {
+    if (tokenPattern.pattern.test(input.content)) {
+      violations.push({
+        code: "token_pattern",
+        path: input.path,
+        line: input.line,
+        pattern: tokenPattern.name,
+        message: `High-confidence ${tokenPattern.name} token appears in the diff.`,
+      });
+    }
+  }
+
+  if (/-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----/.test(input.content)) {
+    violations.push({
+      code: "private_key",
+      path: input.path,
+      line: input.line,
+      message: "Private key material appears in the diff.",
+    });
+  }
+
+  return violations;
+}
+
+function parseDiffPath(line: string): string | null {
+  const match = line.match(/^diff --git a\/(.+) b\/(.+)$/);
+
+  if (match === null) {
+    return null;
+  }
+
+  return match[2] ?? null;
+}
+
+function parseHunkNewStart(line: string): number | null {
+  const match = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+
+  if (match === null) {
+    return null;
+  }
+
+  const newStart = match[1];
+
+  if (newStart === undefined) {
+    return null;
+  }
+
+  return Number.parseInt(newStart, 10);
+}
+
+function isSampleEnvFilePath(path: string): boolean {
+  return (
+    path.endsWith(".env.example") ||
+    path.endsWith(".env.sample") ||
+    path.endsWith(".env.template") ||
+    path.endsWith(".codex-cage.env.example")
+  );
+}
+
+function isScannableSecret(value: string): boolean {
+  return value.length >= minSecretLength;
+}
+
+function unquoteEnvValue(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/test/docker.test.ts
+++ b/test/docker.test.ts
@@ -6,16 +6,19 @@ import {
   dockerRunArgs,
   networkCreateArgs,
   volumeCreateArgs,
+  type DockerRunOptions,
   type DockerRunner,
 } from "../src/docker.js";
 
-function recordingRunner(): DockerRunner & { calls: string[][] } {
-  const calls: string[][] = [];
+function recordingRunner(): DockerRunner & {
+  calls: Array<{ args: string[]; options: DockerRunOptions }>;
+} {
+  const calls: Array<{ args: string[]; options: DockerRunOptions }> = [];
 
   return {
     calls,
-    async run(args: string[]): Promise<void> {
-      calls.push(args);
+    async run(args: string[], options: DockerRunOptions = {}): Promise<void> {
+      calls.push({ args, options });
     },
   };
 }
@@ -100,15 +103,17 @@ test("createDockerSandbox creates resources, clones into volume, runs commands, 
   assert.equal(sandbox.networkName, "codex-cage-run-1");
   assert.equal(sandbox.ownedNetworkName, "codex-cage-run-1");
   assert.equal(runner.calls.length, 6);
-  assert.deepEqual(runner.calls[0]?.slice(0, 2), ["volume", "create"]);
-  assert.deepEqual(runner.calls[1]?.slice(0, 2), ["network", "create"]);
+  assert.deepEqual(runner.calls[0]?.args.slice(0, 2), ["volume", "create"]);
+  assert.deepEqual(runner.calls[1]?.args.slice(0, 2), ["network", "create"]);
   assert.equal(
-    runner.calls[2]?.some((arg) => arg.includes("git clone")),
+    runner.calls[2]?.args.some((arg) => arg.includes("git clone")),
     true,
   );
-  assert.equal(runner.calls[3]?.at(-1), "npm test");
-  assert.deepEqual(runner.calls[4], ["network", "rm", "codex-cage-run-1"]);
-  assert.deepEqual(runner.calls[5], ["volume", "rm", "codex-cage-run-1-workspace"]);
+  assert.equal(runner.calls[3]?.args.at(-1), "npm test");
+  assert.deepEqual(runner.calls[2]?.options.env, { GITHUB_TOKEN: "token" });
+  assert.deepEqual(runner.calls[3]?.options.env, { GITHUB_TOKEN: "token" });
+  assert.deepEqual(runner.calls[4]?.args, ["network", "rm", "codex-cage-run-1"]);
+  assert.deepEqual(runner.calls[5]?.args, ["volume", "rm", "codex-cage-run-1-workspace"]);
 });
 
 test("createDockerSandbox can attach agent commands to an externally managed service network", async () => {
@@ -130,19 +135,22 @@ test("createDockerSandbox can attach agent commands to an externally managed ser
   assert.equal(sandbox.networkName, "codex-cage-run-1_default");
   assert.equal(sandbox.ownedNetworkName, null);
   assert.equal(runner.calls.length, 4);
-  assert.deepEqual(runner.calls[0]?.slice(0, 2), ["volume", "create"]);
+  assert.deepEqual(runner.calls[0]?.args.slice(0, 2), ["volume", "create"]);
   assert.equal(
-    runner.calls.some((call) => call[0] === "network"),
+    runner.calls.some((call) => call.args[0] === "network"),
     false,
   );
   assert.equal(
-    runner.calls[1]?.at((runner.calls[1] ?? []).indexOf("--network") + 1),
+    runner.calls[1]?.args.at((runner.calls[1]?.args ?? []).indexOf("--network") + 1),
     "codex-cage-run-1_default",
   );
   assert.equal(
-    runner.calls[2]?.at((runner.calls[2] ?? []).indexOf("--network") + 1),
+    runner.calls[2]?.args.at((runner.calls[2]?.args ?? []).indexOf("--network") + 1),
     "codex-cage-run-1_default",
   );
-  assert.equal(runner.calls.flat().includes("/var/run/docker.sock"), false);
-  assert.deepEqual(runner.calls[3], ["volume", "rm", "codex-cage-run-1-workspace"]);
+  assert.equal(
+    runner.calls.flatMap((call) => call.args).includes("/var/run/docker.sock"),
+    false,
+  );
+  assert.deepEqual(runner.calls[3]?.args, ["volume", "rm", "codex-cage-run-1-workspace"]);
 });

--- a/test/guards.test.ts
+++ b/test/guards.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  assertNoGuardViolations,
+  createSecretRedactor,
+  formatGuardViolations,
+  guardAttemptDecision,
+  isSensitiveFilePath,
+  parseEnvFile,
+  readCodexCageEnv,
+  scanDiffForGuardViolations,
+} from "../src/guards.js";
+
+async function tempRepo(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "codex-cage-guards-"));
+}
+
+test("parseEnvFile parses simple dotenv assignments without leaking examples", () => {
+  assert.deepEqual(
+    parseEnvFile(`
+# local secrets
+OPENAI_API_KEY=sk-local-secret
+export GITHUB_TOKEN='ghp_local_secret'
+LINEAR_API_KEY="lin-local-secret"
+EMPTY=
+`),
+    {
+      OPENAI_API_KEY: "sk-local-secret",
+      GITHUB_TOKEN: "ghp_local_secret",
+      LINEAR_API_KEY: "lin-local-secret",
+      EMPTY: "",
+    },
+  );
+});
+
+test("parseEnvFile rejects malformed assignments with line numbers", () => {
+  assert.throws(() => parseEnvFile("OPENAI_API_KEY=secret\nnot valid\n"), /line 2/);
+});
+
+test("readCodexCageEnv returns empty env when the local secret file is absent", async () => {
+  const cwd = await tempRepo();
+
+  try {
+    assert.deepEqual(await readCodexCageEnv(cwd), {});
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("readCodexCageEnv reads local secrets from .codex-cage.env", async () => {
+  const cwd = await tempRepo();
+
+  try {
+    await writeFile(join(cwd, ".codex-cage.env"), "GITHUB_TOKEN=ghp_secret\n", "utf8");
+
+    assert.deepEqual(await readCodexCageEnv(cwd), {
+      GITHUB_TOKEN: "ghp_secret",
+    });
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("createSecretRedactor replaces known secret values and ignores empty values", () => {
+  const redact = createSecretRedactor({
+    GITHUB_TOKEN: "ghp_secret",
+    EMPTY: "",
+  });
+
+  assert.equal(
+    redact("clone with ghp_secret but keep ordinary text"),
+    "clone with [REDACTED:GITHUB_TOKEN] but keep ordinary text",
+  );
+});
+
+test("scanDiffForGuardViolations detects injected secrets and high confidence tokens", () => {
+  const diff = `diff --git a/src/app.ts b/src/app.ts
+@@ -1,2 +1,4 @@
+ export const ok = true;
++export const leaked = "known-secret-value";
++export const token = "ghp_123456789012345678901234567890123456";
+`;
+
+  const violations = scanDiffForGuardViolations(diff, {
+    injectedSecrets: {
+      GITHUB_TOKEN: "known-secret-value",
+    },
+  });
+
+  assert.deepEqual(
+    violations.map((violation) => violation.code),
+    ["injected_secret", "token_pattern"],
+  );
+  assert.deepEqual(
+    violations.map((violation) => violation.path),
+    ["src/app.ts", "src/app.ts"],
+  );
+});
+
+test("scanDiffForGuardViolations detects private key material", () => {
+  const diff = `diff --git a/key.pem b/key.pem
+@@ -0,0 +1 @@
++-----BEGIN PRIVATE KEY-----
+`;
+
+  assert.deepEqual(
+    scanDiffForGuardViolations(diff).map((violation) => violation.code),
+    ["private_key"],
+  );
+});
+
+test("scanDiffForGuardViolations denies real env and auth files", () => {
+  const diff = `diff --git a/.env b/.env
+@@ -0,0 +1 @@
++TOKEN=example
+diff --git a/.config/gh/hosts.yml b/.config/gh/hosts.yml
+@@ -0,0 +1 @@
++github.com: {}
+`;
+
+  assert.deepEqual(
+    scanDiffForGuardViolations(diff).map((violation) => violation.code),
+    ["sensitive_file", "sensitive_file"],
+  );
+});
+
+test("assertNoGuardViolations blocks later phases with clear violation details", () => {
+  const violations = scanDiffForGuardViolations(`diff --git a/.env b/.env
+@@ -0,0 +1 @@
++TOKEN=example
+`);
+
+  assert.throws(() => assertNoGuardViolations(violations), {
+    name: "GuardViolationError",
+    message: /\.env \[sensitive_file\] Sensitive file/,
+  });
+  assert.match(formatGuardViolations(violations), /\.env \[sensitive_file\]/);
+});
+
+test("scanDiffForGuardViolations allows sample env files unless content looks secret-bearing", () => {
+  const diff = `diff --git a/.env.example b/.env.example
+@@ -0,0 +1,2 @@
++OPENAI_API_KEY=
++EXAMPLE_SECRET=sk-123456789012345678901234
+`;
+
+  assert.deepEqual(
+    scanDiffForGuardViolations(diff).map((violation) => violation.code),
+    ["token_pattern"],
+  );
+});
+
+test("isSensitiveFilePath classifies auth files and sample env files", () => {
+  assert.equal(isSensitiveFilePath(".codex-cage.env"), true);
+  assert.equal(isSensitiveFilePath(".env"), true);
+  assert.equal(isSensitiveFilePath(".env.example"), false);
+  assert.equal(isSensitiveFilePath(".ssh/id_ed25519"), true);
+  assert.equal(isSensitiveFilePath(".config/gh/hosts.yml"), true);
+});
+
+test("guardAttemptDecision retries within the configured bound and fails after it", () => {
+  assert.deepEqual(guardAttemptDecision({ attempt: 0, maxAttempts: 2 }), {
+    action: "retry",
+    nextAttempt: 1,
+  });
+  assert.deepEqual(guardAttemptDecision({ attempt: 2, maxAttempts: 2 }), {
+    action: "fail",
+    attempts: 3,
+  });
+});


### PR DESCRIPTION
## Summary
- Add guard utilities for parsing .codex-cage.env, redacting known secret values, scanning diffs, and producing blocking guard errors.
- Detect injected secrets, high-confidence token patterns, private key material, and sensitive auth file changes while allowing sample env files to be scanned normally.
- Pass parsed secret env values to Docker via process environment instead of argv, and sync the package-lock CLI bin path.
- Document the secret guard behavior in README.

## Validation
- npm run typecheck
- npm test
- npm run format
- npm --cache /tmp/codex-cage-npm-cache exec -- codex-cage --help
- npm --cache /tmp/codex-cage-npm-cache pack --dry-run

Closes #9