### PR TITLE
Add independent review phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Local secrets live in `.codex-cage.env`, which is parsed by the orchestrator and
 
 Guard scanning checks diffs for injected secret values, high-confidence token patterns, private key material, and sensitive auth files such as `.env`, `.codex-cage.env`, `.npmrc`, `.ssh/*`, `.config/gh/*`, and `.aws/*`. Sample env files like `.env.example`, `.env.sample`, and `.env.template` are allowed, but their added content is still scanned for secret-looking values.
 
+## Independent Review
+
+After implementation verification passes, Codex Cage runs a fresh Codex review process by default. The reviewer receives issue context, the diff against base, result metadata, and the verification summary, and it must return structured JSON with a `pass` or `blocking` decision.
+
+Review is read-only. If the diff changes during review, the run fails instead of publishing. Blocking findings are formatted as implementation feedback until `agent.max_review_cycles` is exhausted.
+
 ## Development
 
 ```bash

--- a/src/review.ts
+++ b/src/review.ts
@@ -1,0 +1,247 @@
+import { execa } from "execa";
+import { z } from "zod";
+
+export type ReviewFindingSeverity = "blocking" | "non_blocking";
+
+export type ReviewFinding = {
+  severity: ReviewFindingSeverity;
+  message: string;
+  path?: string | undefined;
+  line?: number | undefined;
+};
+
+export type ReviewReport = {
+  decision: "pass" | "blocking";
+  summary: string;
+  findings: ReviewFinding[];
+};
+
+export type ReviewNextAction =
+  | { action: "continue" }
+  | { action: "fix"; nextCycle: number; feedback: string }
+  | { action: "fail"; failureCode: "review_blocking"; feedback: string };
+
+export type ReviewAgentRunInput = {
+  cwd: string;
+  model: string;
+  prompt: string;
+  env?: Record<string, string> | undefined;
+};
+
+export type ReviewAgentRunner = {
+  run: (input: ReviewAgentRunInput) => Promise<string>;
+};
+
+export type BuildReviewPromptInput = {
+  issueContext: string;
+  diff: string;
+  verificationSummary: string;
+  resultMetadata: Record<string, unknown>;
+};
+
+export type RunIndependentReviewInput = BuildReviewPromptInput & {
+  cwd: string;
+  model: string;
+  cycle: number;
+  maxReviewCycles: number;
+  readCurrentDiff: () => Promise<string>;
+  runner?: ReviewAgentRunner;
+  env?: Record<string, string>;
+};
+
+export type RunIndependentReviewResult = {
+  report: ReviewReport;
+  nextAction: ReviewNextAction;
+};
+
+export class ReviewModifiedDiffError extends Error {
+  constructor() {
+    super("Review phase modified the diff. Review must be read-only.");
+    this.name = "ReviewModifiedDiffError";
+  }
+}
+
+const reviewFindingSchema = z
+  .object({
+    severity: z.enum(["blocking", "non_blocking"]),
+    message: z.string().min(1),
+    path: z.string().min(1).optional(),
+    line: z.number().int().positive().optional(),
+  })
+  .strict();
+
+const reviewReportSchema = z
+  .object({
+    decision: z.enum(["pass", "blocking"]),
+    summary: z.string().min(1),
+    findings: z.array(reviewFindingSchema),
+  })
+  .strict()
+  .superRefine((report, context) => {
+    const hasBlockingFinding = report.findings.some(
+      (finding) => finding.severity === "blocking",
+    );
+
+    if (report.decision === "pass" && hasBlockingFinding) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Passing review reports cannot contain blocking findings.",
+        path: ["findings"],
+      });
+    }
+
+    if (report.decision === "blocking" && !hasBlockingFinding) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Blocking review reports must contain at least one blocking finding.",
+        path: ["findings"],
+      });
+    }
+  });
+
+export const execaReviewAgentRunner: ReviewAgentRunner = {
+  async run(input: ReviewAgentRunInput): Promise<string> {
+    const args = ["exec", "--model", input.model, "--cwd", input.cwd, input.prompt];
+
+    if (input.env === undefined) {
+      const result = await execa("codex", args);
+      return result.stdout;
+    }
+
+    const result = await execa("codex", args, { env: input.env });
+    return result.stdout;
+  },
+};
+
+export async function runIndependentReview(
+  input: RunIndependentReviewInput,
+): Promise<RunIndependentReviewResult> {
+  const runner = input.runner ?? execaReviewAgentRunner;
+  const prompt = buildReviewPrompt(input);
+  const output = await runner.run({
+    cwd: input.cwd,
+    model: input.model,
+    prompt,
+    env: input.env,
+  });
+  const currentDiff = await input.readCurrentDiff();
+
+  if (currentDiff !== input.diff) {
+    throw new ReviewModifiedDiffError();
+  }
+
+  const report = parseReviewReport(output);
+
+  return {
+    report,
+    nextAction: reviewNextAction({
+      report,
+      cycle: input.cycle,
+      maxReviewCycles: input.maxReviewCycles,
+    }),
+  };
+}
+
+export function buildReviewPrompt(input: BuildReviewPromptInput): string {
+  return `You are the independent Codex Cage review agent.
+
+Review the implementation as a read-only reviewer. Do not edit files, commit, push, run destructive commands, create PRs, or write secrets.
+
+Evaluate whether the diff satisfies the issue and whether verified behavior is credible. Treat security, data loss, broken tests, and missing required behavior as blocking.
+
+Return only JSON matching this schema:
+{
+  "decision": "pass" | "blocking",
+  "summary": "short review summary",
+  "findings": [
+    {
+      "severity": "blocking" | "non_blocking",
+      "message": "specific finding",
+      "path": "optional/file/path",
+      "line": 123
+    }
+  ]
+}
+
+Issue context:
+${input.issueContext}
+
+Verification summary:
+${input.verificationSummary}
+
+Result metadata:
+${JSON.stringify(input.resultMetadata, null, 2)}
+
+Diff against base:
+${input.diff}
+`;
+}
+
+export function parseReviewReport(output: string): ReviewReport {
+  const jsonText = extractJsonObject(output);
+  const parsed = JSON.parse(jsonText) as unknown;
+
+  return reviewReportSchema.parse(parsed);
+}
+
+export function reviewNextAction(input: {
+  report: ReviewReport;
+  cycle: number;
+  maxReviewCycles: number;
+}): ReviewNextAction {
+  if (input.report.decision === "pass") {
+    return { action: "continue" };
+  }
+
+  const feedback = blockingReviewFeedback(input.report);
+
+  if (input.cycle >= input.maxReviewCycles) {
+    return { action: "fail", failureCode: "review_blocking", feedback };
+  }
+
+  return {
+    action: "fix",
+    nextCycle: input.cycle + 1,
+    feedback,
+  };
+}
+
+export function blockingReviewFeedback(report: ReviewReport): string {
+  const blockingFindings = report.findings.filter(
+    (finding) => finding.severity === "blocking",
+  );
+
+  if (blockingFindings.length === 0) {
+    return report.summary;
+  }
+
+  return blockingFindings
+    .map((finding, index) => {
+      const location =
+        finding.path === undefined
+          ? ""
+          : finding.line === undefined
+            ? ` (${finding.path})`
+            : ` (${finding.path}:${finding.line})`;
+
+      return `${index + 1}. ${finding.message}${location}`;
+    })
+    .join("\n");
+}
+
+function extractJsonObject(output: string): string {
+  const fencedJson = output.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1]?.trim();
+
+  if (fencedJson !== undefined) {
+    return fencedJson;
+  }
+
+  const firstBrace = output.indexOf("{");
+  const lastBrace = output.lastIndexOf("}");
+
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace < firstBrace) {
+    throw new Error("Review agent did not return a JSON object.");
+  }
+
+  return output.slice(firstBrace, lastBrace + 1);
+}

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  blockingReviewFeedback,
+  buildReviewPrompt,
+  parseReviewReport,
+  reviewNextAction,
+  runIndependentReview,
+  type ReviewAgentRunner,
+} from "../src/review.js";
+
+function recordingReviewRunner(output: string): ReviewAgentRunner & {
+  calls: Array<Parameters<ReviewAgentRunner["run"]>[0]>;
+} {
+  const calls: Array<Parameters<ReviewAgentRunner["run"]>[0]> = [];
+
+  return {
+    calls,
+    async run(input): Promise<string> {
+      calls.push(input);
+      return output;
+    },
+  };
+}
+
+const passReportJson = JSON.stringify({
+  decision: "pass",
+  summary: "No blocking issues.",
+  findings: [],
+});
+
+const blockingReportJson = JSON.stringify({
+  decision: "blocking",
+  summary: "Needs a fix.",
+  findings: [
+    {
+      severity: "blocking",
+      message: "Verification command is not wired.",
+      path: "src/run.ts",
+      line: 42,
+    },
+  ],
+});
+
+test("buildReviewPrompt includes read-only instructions and required context", () => {
+  const prompt = buildReviewPrompt({
+    issueContext: "Issue: add review",
+    diff: "diff --git a/src/app.ts b/src/app.ts",
+    verificationSummary: "npm test passed",
+    resultMetadata: {
+      runId: "run-1",
+      verify: ["npm test"],
+    },
+  });
+
+  assert.match(prompt, /read-only reviewer/);
+  assert.match(prompt, /Do not edit files/);
+  assert.match(prompt, /Issue: add review/);
+  assert.match(prompt, /npm test passed/);
+  assert.match(prompt, /"runId": "run-1"/);
+  assert.match(prompt, /diff --git/);
+});
+
+test("parseReviewReport accepts strict structured JSON from the review agent", () => {
+  assert.deepEqual(parseReviewReport(`\n\`\`\`json\n${blockingReportJson}\n\`\`\`\n`), {
+    decision: "blocking",
+    summary: "Needs a fix.",
+    findings: [
+      {
+        severity: "blocking",
+        message: "Verification command is not wired.",
+        path: "src/run.ts",
+        line: 42,
+      },
+    ],
+  });
+});
+
+test("parseReviewReport rejects passing reports with blocking findings", () => {
+  assert.throws(
+    () =>
+      parseReviewReport(
+        JSON.stringify({
+          decision: "pass",
+          summary: "looks good",
+          findings: [{ severity: "blocking", message: "bug" }],
+        }),
+      ),
+    /Passing review reports cannot contain blocking findings/,
+  );
+});
+
+test("reviewNextAction allows passing review to continue", () => {
+  assert.deepEqual(
+    reviewNextAction({
+      report: parseReviewReport(passReportJson),
+      cycle: 0,
+      maxReviewCycles: 2,
+    }),
+    { action: "continue" },
+  );
+});
+
+test("reviewNextAction feeds blocking findings back until max review cycles", () => {
+  assert.deepEqual(
+    reviewNextAction({
+      report: parseReviewReport(blockingReportJson),
+      cycle: 0,
+      maxReviewCycles: 2,
+    }),
+    {
+      action: "fix",
+      nextCycle: 1,
+      feedback: "1. Verification command is not wired. (src/run.ts:42)",
+    },
+  );
+
+  assert.deepEqual(
+    reviewNextAction({
+      report: parseReviewReport(blockingReportJson),
+      cycle: 2,
+      maxReviewCycles: 2,
+    }),
+    {
+      action: "fail",
+      failureCode: "review_blocking",
+      feedback: "1. Verification command is not wired. (src/run.ts:42)",
+    },
+  );
+});
+
+test("blockingReviewFeedback formats blocking findings for the implementer", () => {
+  assert.equal(
+    blockingReviewFeedback(parseReviewReport(blockingReportJson)),
+    "1. Verification command is not wired. (src/run.ts:42)",
+  );
+});
+
+test("runIndependentReview runs a fresh review runner and returns parsed action", async () => {
+  const runner = recordingReviewRunner(passReportJson);
+  const diff = "diff --git a/src/app.ts b/src/app.ts";
+  const result = await runIndependentReview({
+    cwd: "/repo",
+    model: "gpt-5.4",
+    cycle: 0,
+    maxReviewCycles: 2,
+    issueContext: "Issue context",
+    diff,
+    verificationSummary: "npm test passed",
+    resultMetadata: { runId: "run-1" },
+    readCurrentDiff: async () => diff,
+    runner,
+    env: { OPENAI_API_KEY: "secret" },
+  });
+
+  assert.equal(runner.calls.length, 1);
+  assert.equal(runner.calls[0]?.cwd, "/repo");
+  assert.equal(runner.calls[0]?.model, "gpt-5.4");
+  assert.deepEqual(runner.calls[0]?.env, { OPENAI_API_KEY: "secret" });
+  assert.equal(result.report.decision, "pass");
+  assert.deepEqual(result.nextAction, { action: "continue" });
+});
+
+test("runIndependentReview fails if the read-only review changes the diff", async () => {
+  const runner = recordingReviewRunner(passReportJson);
+
+  await assert.rejects(
+    () =>
+      runIndependentReview({
+        cwd: "/repo",
+        model: "gpt-5.4",
+        cycle: 0,
+        maxReviewCycles: 2,
+        issueContext: "Issue context",
+        diff: "before",
+        verificationSummary: "npm test passed",
+        resultMetadata: { runId: "run-1" },
+        readCurrentDiff: async () => "after",
+        runner,
+      }),
+    { name: "ReviewModifiedDiffError" },
+  );
+});


### PR DESCRIPTION
## Summary
- Add an independent review module that builds a read-only Codex review prompt from issue context, base diff, verification summary, and run metadata.
- Require structured review JSON with pass/blocking decisions and validate the report shape.
- Detect review-time diff changes and return bounded next actions for continue, implementation fix, or review-blocking failure.
- Document the default independent review behavior in README.

## Validation
- npm run typecheck
- npm test
- npm run format
- npm --cache /tmp/codex-cage-npm-cache exec -- codex-cage --help
- npm --cache /tmp/codex-cage-npm-cache pack --dry-run

Closes #10