### PR TITLE
Add publish PR phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ After implementation verification passes, Codex Cage runs a fresh Codex review p
 
 Review is read-only. If the diff changes during review, the run fails instead of publishing. Blocking findings are formatted as implementation feedback until `agent.max_review_cycles` is exhausted.
 
+## Publishing
+
+Successful runs are published by the orchestrator, not by the implementation or review agents. Codex Cage rejects empty diffs, creates a run-specific branch, configures the Codex Cage git author, commits once, pushes without force, and creates a ready GitHub PR by default.
+
+PR bodies include the summary, verification, review status, risks, run id, and issue linkage. GitHub issues use closing keywords such as `Closes #123`; Linear issues are linked without mutating Linear.
+
 ## Development
 
 ```bash

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -1,0 +1,284 @@
+import { execa } from "execa";
+import type { IssueContext } from "./issue.js";
+import type { GithubRepo } from "./repo.js";
+
+export type CommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+export type CommandRunner = {
+  run: (args: string[], options?: CommandRunOptions) => Promise<CommandResult>;
+};
+
+export type CommandRunOptions = {
+  cwd?: string | undefined;
+};
+
+export type PublishMetadata = {
+  runId: string;
+  summary: string;
+  verification: string[];
+  reviewStatus: string;
+  risks: string[];
+};
+
+export type PublishSuccessfulRunInput = {
+  cwd: string;
+  repo: GithubRepo;
+  issue: IssueContext;
+  baseBranch: string;
+  authorName: string;
+  authorEmail: string;
+  metadata: PublishMetadata;
+  branchName?: string | undefined;
+  draft?: boolean | undefined;
+  git?: CommandRunner | undefined;
+  gh?: CommandRunner | undefined;
+};
+
+export type PublishSuccessfulRunResult = {
+  branchName: string;
+  commitMessage: string;
+  prTitle: string;
+  prBody: string;
+  prUrl: string;
+};
+
+export class NoDiffError extends Error {
+  constructor() {
+    super("No changes to publish.");
+    this.name = "NoDiffError";
+  }
+}
+
+export class BranchExistsError extends Error {
+  constructor(branchName: string) {
+    super(`Branch "${branchName}" already exists.`);
+    this.name = "BranchExistsError";
+  }
+}
+
+export const execaGitRunner: CommandRunner = {
+  async run(args: string[], options: CommandRunOptions = {}): Promise<CommandResult> {
+    const result =
+      options.cwd === undefined
+        ? await execa("git", args, { reject: false })
+        : await execa("git", args, {
+            cwd: options.cwd,
+            reject: false,
+          });
+
+    return {
+      exitCode: result.exitCode ?? 0,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  },
+};
+
+export const execaGhRunner: CommandRunner = {
+  async run(args: string[], options: CommandRunOptions = {}): Promise<CommandResult> {
+    const result =
+      options.cwd === undefined
+        ? await execa("gh", args, { reject: false })
+        : await execa("gh", args, {
+            cwd: options.cwd,
+            reject: false,
+          });
+
+    return {
+      exitCode: result.exitCode ?? 0,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  },
+};
+
+export async function publishSuccessfulRun(
+  input: PublishSuccessfulRunInput,
+): Promise<PublishSuccessfulRunResult> {
+  const git = input.git ?? execaGitRunner;
+  const gh = input.gh ?? execaGhRunner;
+  const branchName =
+    input.branchName ??
+    generateBranchName({
+      issue: input.issue,
+      runId: input.metadata.runId,
+    });
+
+  if (!(await hasPublishableChanges({ cwd: input.cwd, git }))) {
+    throw new NoDiffError();
+  }
+
+  if (await branchExists({ cwd: input.cwd, branchName, git })) {
+    throw new BranchExistsError(branchName);
+  }
+
+  const prTitle = prTitleFromIssue(input.issue);
+  const commitMessage = prTitle;
+  const prBody = formatPrBody({
+    issue: input.issue,
+    metadata: input.metadata,
+  });
+
+  await runRequired(git, ["checkout", "-b", branchName], input.cwd);
+  await runRequired(git, ["config", "user.name", input.authorName], input.cwd);
+  await runRequired(git, ["config", "user.email", input.authorEmail], input.cwd);
+  await runRequired(git, ["add", "--all"], input.cwd);
+  await runRequired(git, ["commit", "-m", commitMessage], input.cwd);
+  await runRequired(git, ["push", "-u", "origin", branchName], input.cwd);
+
+  const prCreateArgs = [
+    "pr",
+    "create",
+    "--repo",
+    input.repo.fullName,
+    "--base",
+    input.baseBranch,
+    "--head",
+    branchName,
+    "--title",
+    prTitle,
+    "--body",
+    prBody,
+  ];
+
+  if (input.draft === true) {
+    prCreateArgs.push("--draft");
+  }
+
+  const prResult = await runRequired(gh, prCreateArgs, input.cwd);
+  const prUrl = prResult.stdout.trim();
+
+  return {
+    branchName,
+    commitMessage,
+    prTitle,
+    prBody,
+    prUrl,
+  };
+}
+
+export function generateBranchName(input: {
+  issue: IssueContext;
+  runId: string;
+}): string {
+  const source = input.issue.source === "github" ? "gh" : "linear";
+  const issueId = sanitizeBranchSegment(input.issue.identifier);
+  const runId = sanitizeBranchSegment(input.runId)
+    .replace(/^run-?/, "")
+    .slice(0, 12);
+
+  return `codex-cage/${source}-${issueId}-run-${runId}`;
+}
+
+export async function hasPublishableChanges(input: {
+  cwd: string;
+  git?: CommandRunner;
+}): Promise<boolean> {
+  const git = input.git ?? execaGitRunner;
+  const result = await git.run(["status", "--porcelain"], { cwd: input.cwd });
+
+  if (result.exitCode !== 0) {
+    throw new Error(`Could not inspect git status: ${result.stderr}`);
+  }
+
+  return result.stdout.trim() !== "";
+}
+
+export async function branchExists(input: {
+  cwd: string;
+  branchName: string;
+  git?: CommandRunner;
+}): Promise<boolean> {
+  const git = input.git ?? execaGitRunner;
+  const local = await git.run(
+    ["rev-parse", "--verify", `refs/heads/${input.branchName}`],
+    { cwd: input.cwd },
+  );
+
+  if (local.exitCode === 0) {
+    return true;
+  }
+
+  const remote = await git.run(
+    ["ls-remote", "--exit-code", "--heads", "origin", input.branchName],
+    { cwd: input.cwd },
+  );
+
+  return remote.exitCode === 0;
+}
+
+export function formatPrBody(input: {
+  issue: IssueContext;
+  metadata: PublishMetadata;
+}): string {
+  const risks =
+    input.metadata.risks.length === 0
+      ? "- None noted."
+      : input.metadata.risks.map((risk) => `- ${risk}`).join("\n");
+  const verification =
+    input.metadata.verification.length === 0
+      ? "- Not recorded."
+      : input.metadata.verification.map((item) => `- ${item}`).join("\n");
+
+  return `## Summary
+${input.metadata.summary}
+
+## Verification
+${verification}
+
+## Review
+${input.metadata.reviewStatus}
+
+## Risks
+${risks}
+
+## Run
+- Run ID: ${input.metadata.runId}
+
+## Issue
+${formatIssueLinkage(input.issue)}
+`;
+}
+
+export function formatIssueLinkage(issue: IssueContext): string {
+  if (issue.source === "github") {
+    return `- ${issue.url}\n- Closes ${issue.identifier}`;
+  }
+
+  return `- Linear: ${issue.url}`;
+}
+
+function prTitleFromIssue(issue: IssueContext): string {
+  return `${issue.identifier} ${issue.title}`;
+}
+
+function sanitizeBranchSegment(value: string): string {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (normalized === "") {
+    return "issue";
+  }
+
+  return normalized;
+}
+
+async function runRequired(
+  runner: CommandRunner,
+  args: string[],
+  cwd: string,
+): Promise<CommandResult> {
+  const result = await runner.run(args, { cwd });
+
+  if (result.exitCode !== 0) {
+    throw new Error(`Command failed: ${args.join(" ")}\n${result.stderr}`);
+  }
+
+  return result;
+}

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -1,0 +1,302 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { IssueContext } from "../src/issue.js";
+import {
+  BranchExistsError,
+  NoDiffError,
+  branchExists,
+  formatIssueLinkage,
+  formatPrBody,
+  generateBranchName,
+  hasPublishableChanges,
+  publishSuccessfulRun,
+  type CommandResult,
+  type CommandRunner,
+} from "../src/publish.js";
+import type { GithubRepo } from "../src/repo.js";
+
+type RecordedCall = {
+  args: string[];
+  cwd: string | undefined;
+};
+
+function result(stdout = "", exitCode = 0, stderr = ""): CommandResult {
+  return { exitCode, stdout, stderr };
+}
+
+function recordingRunner(results: CommandResult[]): CommandRunner & {
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+
+  return {
+    calls,
+    async run(args, options): Promise<CommandResult> {
+      calls.push({ args, cwd: options?.cwd });
+      const next = results.shift();
+
+      if (next === undefined) {
+        throw new Error(`Unexpected command: ${args.join(" ")}`);
+      }
+
+      return next;
+    },
+  };
+}
+
+const repo: GithubRepo = {
+  owner: "jhowliu",
+  name: "codex-cage",
+  fullName: "jhowliu/codex-cage",
+};
+
+const githubIssue: IssueContext = {
+  source: "github",
+  url: "https://github.com/jhowliu/codex-cage/issues/11",
+  identifier: "#11",
+  title: "Publish successful runs",
+  body: "Create PRs after checks pass.",
+  comments: [],
+  inferredRepo: "jhowliu/codex-cage",
+};
+
+const linearIssue: IssueContext = {
+  source: "linear",
+  url: "https://linear.app/acme/issue/ENG-123/publish",
+  identifier: "ENG-123",
+  title: "Publish successful runs",
+  body: "Create PRs after checks pass.",
+  comments: [],
+  inferredRepo: null,
+};
+
+const metadata = {
+  runId: "run-1234567890abcdef",
+  summary: "Implemented publish flow.",
+  verification: ["npm test", "npm run format"],
+  reviewStatus: "Independent review passed.",
+  risks: ["GitHub API unavailable would fail publishing."],
+};
+
+test("generateBranchName creates run-specific branch names", () => {
+  assert.equal(
+    generateBranchName({ issue: githubIssue, runId: metadata.runId }),
+    "codex-cage/gh-11-run-1234567890ab",
+  );
+  assert.equal(
+    generateBranchName({ issue: linearIssue, runId: metadata.runId }),
+    "codex-cage/linear-eng-123-run-1234567890ab",
+  );
+});
+
+test("formatPrBody includes summary, verification, review, risks, run id, and GitHub closing keyword", () => {
+  const body = formatPrBody({ issue: githubIssue, metadata });
+
+  assert.match(body, /## Summary\nImplemented publish flow/);
+  assert.match(body, /- npm test/);
+  assert.match(body, /Independent review passed/);
+  assert.match(body, /GitHub API unavailable/);
+  assert.match(body, /Run ID: run-1234567890abcdef/);
+  assert.match(body, /Closes #11/);
+});
+
+test("formatIssueLinkage links Linear issues without closing or mutating them", () => {
+  assert.equal(
+    formatIssueLinkage(linearIssue),
+    "- Linear: https://linear.app/acme/issue/ENG-123/publish",
+  );
+});
+
+test("hasPublishableChanges rejects empty status and accepts changed status", async () => {
+  assert.equal(
+    await hasPublishableChanges({
+      cwd: "/repo",
+      git: recordingRunner([result("")]),
+    }),
+    false,
+  );
+  assert.equal(
+    await hasPublishableChanges({
+      cwd: "/repo",
+      git: recordingRunner([result(" M src/app.ts\n?? src/new.ts\n")]),
+    }),
+    true,
+  );
+});
+
+test("branchExists checks local and remote branches without creating or force pushing", async () => {
+  const git = recordingRunner([result("", 1), result("", 0)]);
+
+  assert.equal(
+    await branchExists({
+      cwd: "/repo",
+      branchName: "codex-cage/gh-11-run-1",
+      git,
+    }),
+    true,
+  );
+  assert.deepEqual(
+    git.calls.map((call) => call.args),
+    [
+      ["rev-parse", "--verify", "refs/heads/codex-cage/gh-11-run-1"],
+      ["ls-remote", "--exit-code", "--heads", "origin", "codex-cage/gh-11-run-1"],
+    ],
+  );
+});
+
+test("publishSuccessfulRun creates one branch, one commit, one push, and one ready PR", async () => {
+  const git = recordingRunner([
+    result(" M src/app.ts\n"),
+    result("", 1),
+    result("", 1),
+    result(),
+    result(),
+    result(),
+    result(),
+    result(),
+    result(),
+  ]);
+  const gh = recordingRunner([result("https://github.com/jhowliu/codex-cage/pull/23\n")]);
+
+  const publish = await publishSuccessfulRun({
+    cwd: "/repo",
+    repo,
+    issue: githubIssue,
+    baseBranch: "main",
+    authorName: "Codex Cage",
+    authorEmail: "codex-cage@users.noreply.github.com",
+    metadata,
+    git,
+    gh,
+  });
+
+  assert.equal(publish.branchName, "codex-cage/gh-11-run-1234567890ab");
+  assert.equal(publish.commitMessage, "#11 Publish successful runs");
+  assert.equal(publish.prTitle, "#11 Publish successful runs");
+  assert.equal(publish.prUrl, "https://github.com/jhowliu/codex-cage/pull/23");
+  assert.deepEqual(
+    git.calls.map((call) => call.args),
+    [
+      ["status", "--porcelain"],
+      ["rev-parse", "--verify", "refs/heads/codex-cage/gh-11-run-1234567890ab"],
+      [
+        "ls-remote",
+        "--exit-code",
+        "--heads",
+        "origin",
+        "codex-cage/gh-11-run-1234567890ab",
+      ],
+      ["checkout", "-b", "codex-cage/gh-11-run-1234567890ab"],
+      ["config", "user.name", "Codex Cage"],
+      ["config", "user.email", "codex-cage@users.noreply.github.com"],
+      ["add", "--all"],
+      ["commit", "-m", "#11 Publish successful runs"],
+      ["push", "-u", "origin", "codex-cage/gh-11-run-1234567890ab"],
+    ],
+  );
+  assert.equal(
+    git.calls.some(
+      (call) => call.args.includes("--force") || call.args.includes("--force-with-lease"),
+    ),
+    false,
+  );
+  assert.equal(
+    git.calls.some((call) => call.args[0] === "rebase"),
+    false,
+  );
+  assert.deepEqual(gh.calls[0]?.args.slice(0, 8), [
+    "pr",
+    "create",
+    "--repo",
+    "jhowliu/codex-cage",
+    "--base",
+    "main",
+    "--head",
+    "codex-cage/gh-11-run-1234567890ab",
+  ]);
+  assert.equal(gh.calls[0]?.args.includes("--draft"), false);
+});
+
+test("publishSuccessfulRun supports explicit draft PRs only when requested", async () => {
+  const git = recordingRunner([
+    result(" M src/app.ts\n"),
+    result("", 1),
+    result("", 1),
+    result(),
+    result(),
+    result(),
+    result(),
+    result(),
+    result(),
+  ]);
+  const gh = recordingRunner([result("https://github.com/jhowliu/codex-cage/pull/24\n")]);
+
+  await publishSuccessfulRun({
+    cwd: "/repo",
+    repo,
+    issue: githubIssue,
+    baseBranch: "main",
+    authorName: "Codex Cage",
+    authorEmail: "codex-cage@users.noreply.github.com",
+    metadata,
+    draft: true,
+    git,
+    gh,
+  });
+
+  assert.equal(gh.calls[0]?.args.includes("--draft"), true);
+});
+
+test("publishSuccessfulRun rejects empty diffs before branch creation", async () => {
+  const git = recordingRunner([result("")]);
+  const gh = recordingRunner([]);
+
+  await assert.rejects(
+    () =>
+      publishSuccessfulRun({
+        cwd: "/repo",
+        repo,
+        issue: githubIssue,
+        baseBranch: "main",
+        authorName: "Codex Cage",
+        authorEmail: "codex-cage@users.noreply.github.com",
+        metadata,
+        git,
+        gh,
+      }),
+    NoDiffError,
+  );
+  assert.deepEqual(
+    git.calls.map((call) => call.args),
+    [["status", "--porcelain"]],
+  );
+  assert.equal(gh.calls.length, 0);
+});
+
+test("publishSuccessfulRun fails branch collisions without force pushing", async () => {
+  const git = recordingRunner([result(" M src/app.ts\n"), result("", 0)]);
+  const gh = recordingRunner([]);
+
+  await assert.rejects(
+    () =>
+      publishSuccessfulRun({
+        cwd: "/repo",
+        repo,
+        issue: githubIssue,
+        baseBranch: "main",
+        authorName: "Codex Cage",
+        authorEmail: "codex-cage@users.noreply.github.com",
+        metadata,
+        git,
+        gh,
+      }),
+    BranchExistsError,
+  );
+  assert.equal(
+    git.calls.some(
+      (call) => call.args.includes("--force") || call.args.includes("--force-with-lease"),
+    ),
+    false,
+  );
+  assert.equal(gh.calls.length, 0);
+});


### PR DESCRIPTION
## Summary
- Add a publish module that rejects empty diffs, generates run-specific branch names, checks local/remote branch collisions, commits once with the configured Codex Cage author, pushes without force, and creates a ready GitHub PR by default.
- Generate PR bodies from structured metadata with summary, verification, review status, risks, run id, and issue linkage.
- Add GitHub closing keywords and Linear issue links without mutating Linear.
- Document publishing behavior in README.

## Validation
- npm run typecheck
- npm test
- npm run format
- npm --cache /tmp/codex-cage-npm-cache exec -- codex-cage --help
- npm --cache /tmp/codex-cage-npm-cache pack --dry-run

Closes #11