### PR TITLE
Add Docker cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ Successful runs are published by the orchestrator, not by the implementation or 
 
 PR bodies include the summary, verification, review status, risks, run id, and issue linkage. GitHub issues use closing keywords such as `Closes #123`; Linear issues are linked without mutating Linear.
 
+## Cleanup
+
+```bash
+codex-cage cleanup
+codex-cage cleanup --all
+```
+
+Cleanup removes Docker resources labeled as managed by Codex Cage. By default it removes stopped containers plus networks and volumes for runs without active managed containers. `--all` also removes active managed containers and their networks and volumes. Cleanup never deletes `.codex-cage/runs` artifacts or the SQLite database.
+
 ## Development
 
 ```bash

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { cleanupManagedDockerResources, type CleanupDockerReport } from "./docker.js";
 import { initProject } from "./init.js";
 import { openRunStore } from "./state.js";
 import { readPackageVersion } from "./version.js";
@@ -127,7 +128,36 @@ export function createCli(): Command {
     .command("cleanup")
     .description("Remove stale Docker resources managed by Codex Cage.")
     .option("--all", "remove all managed Docker resources, including active ones")
-    .action(notImplemented("cleanup"));
+    .action(async (options: { all?: boolean }) => {
+      const report = await cleanupManagedDockerResources({ all: options.all === true });
+      console.log(formatCleanupReport(report));
+    });
 
   return program;
+}
+
+function formatCleanupReport(report: CleanupDockerReport): string {
+  const lines = [
+    `Removed containers: ${formatRemovedResources(report.containers)}`,
+    `Removed networks: ${formatRemovedResources(report.networks)}`,
+    `Removed volumes: ${formatRemovedResources(report.volumes)}`,
+  ];
+
+  if (report.skippedActiveRunIds.length > 0) {
+    lines.push(`Skipped active runs: ${report.skippedActiveRunIds.join(", ")}`);
+  }
+
+  if (
+    report.containers.length === 0 &&
+    report.networks.length === 0 &&
+    report.volumes.length === 0
+  ) {
+    lines.push("No managed Docker resources removed.");
+  }
+
+  return lines.join("\n");
+}
+
+function formatRemovedResources(resources: string[]): string {
+  return resources.length === 0 ? "none" : resources.join(", ");
 }

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -4,6 +4,16 @@ export type DockerRunner = {
   run: (args: string[], options?: DockerRunOptions) => Promise<void>;
 };
 
+export type DockerCommandRunner = {
+  run: (args: string[]) => Promise<DockerCommandResult>;
+};
+
+export type DockerCommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
 export type DockerRunOptions = {
   env?: Record<string, string>;
 };
@@ -36,10 +46,24 @@ export type DockerResourceNames = {
   networkName: string;
 };
 
+export type CleanupDockerOptions = {
+  all?: boolean;
+  runner?: DockerCommandRunner;
+};
+
+export type CleanupDockerReport = {
+  containers: string[];
+  networks: string[];
+  volumes: string[];
+  skippedActiveRunIds: string[];
+};
+
 export const defaultSandboxImage = "codex-cage/base:0.1.0";
 export const defaultWorkspacePath = "/workspace";
 
 const runIdLabelName = "codex-cage.run_id";
+const managedLabelName = "codex-cage.managed";
+const managedLabel = `${managedLabelName}=true`;
 
 export const execaDockerRunner: DockerRunner = {
   async run(args: string[], options: DockerRunOptions = {}): Promise<void> {
@@ -49,6 +73,18 @@ export const execaDockerRunner: DockerRunner = {
     }
 
     await execa("docker", args, { env: options.env, stdio: "inherit" });
+  },
+};
+
+export const execaDockerCommandRunner: DockerCommandRunner = {
+  async run(args: string[]): Promise<DockerCommandResult> {
+    const result = await execa("docker", args, { reject: false });
+
+    return {
+      exitCode: result.exitCode ?? 0,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
   },
 };
 
@@ -124,6 +160,60 @@ export async function cleanupDockerResources(
   await runner.run(["volume", "rm", resources.volumeName]);
 }
 
+export async function cleanupManagedDockerResources(
+  options: CleanupDockerOptions = {},
+): Promise<CleanupDockerReport> {
+  const runner = options.runner ?? execaDockerCommandRunner;
+  const all = options.all === true;
+  const containers = await listManagedContainers(runner);
+  const activeRunIds = new Set(
+    containers
+      .filter((container) => container.state === "running")
+      .map((container) => container.runId)
+      .filter((runId): runId is string => runId !== null),
+  );
+  const containersToRemove = containers
+    .filter((container) => all || container.state !== "running")
+    .map((container) => container.id);
+  const networksToRemove = (await listManagedNamedResources(runner, "network")).filter(
+    (resource) => all || resource.runId === null || !activeRunIds.has(resource.runId),
+  );
+  const volumesToRemove = (await listManagedNamedResources(runner, "volume")).filter(
+    (resource) => all || resource.runId === null || !activeRunIds.has(resource.runId),
+  );
+
+  if (containersToRemove.length > 0) {
+    await runRequiredDockerCommand(runner, [
+      "rm",
+      ...(all ? ["--force"] : []),
+      ...containersToRemove,
+    ]);
+  }
+
+  if (networksToRemove.length > 0) {
+    await runRequiredDockerCommand(runner, [
+      "network",
+      "rm",
+      ...networksToRemove.map((resource) => resource.name),
+    ]);
+  }
+
+  if (volumesToRemove.length > 0) {
+    await runRequiredDockerCommand(runner, [
+      "volume",
+      "rm",
+      ...volumesToRemove.map((resource) => resource.name),
+    ]);
+  }
+
+  return {
+    containers: containersToRemove,
+    networks: networksToRemove.map((resource) => resource.name),
+    volumes: volumesToRemove.map((resource) => resource.name),
+    skippedActiveRunIds: all ? [] : [...activeRunIds].sort(),
+  };
+}
+
 export function dockerResourceNames(runId: string): DockerResourceNames {
   const safeRunId = runId
     .toLowerCase()
@@ -186,7 +276,7 @@ export function dockerRunArgs(input: DockerRunArgsInput): string[] {
 }
 
 function labelArgs(labels: Record<string, string>): string[] {
-  return Object.entries({ "codex-cage.managed": "true", ...labels }).flatMap(
+  return Object.entries({ [managedLabelName]: "true", ...labels }).flatMap(
     ([key, value]) => ["--label", `${key}=${value}`],
   );
 }
@@ -199,4 +289,88 @@ function envArgs(env: Record<string, string>): string[] {
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+type ManagedContainer = {
+  id: string;
+  state: string;
+  runId: string | null;
+};
+
+type ManagedNamedResource = {
+  name: string;
+  runId: string | null;
+};
+
+async function listManagedContainers(
+  runner: DockerCommandRunner,
+): Promise<ManagedContainer[]> {
+  const result = await runRequiredDockerCommand(runner, [
+    "ps",
+    "--all",
+    "--filter",
+    `label=${managedLabel}`,
+    "--format",
+    `{{.ID}}\t{{.State}}\t{{.Label "${runIdLabelName}"}}`,
+  ]);
+
+  return result.stdout
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== "")
+    .map((line) => {
+      const [id, state, runId] = line.split("\t");
+
+      if (id === undefined || state === undefined) {
+        throw new Error(`Unexpected docker ps output: ${line}`);
+      }
+
+      return {
+        id,
+        state,
+        runId: runId === undefined || runId === "" ? null : runId,
+      };
+    });
+}
+
+async function listManagedNamedResources(
+  runner: DockerCommandRunner,
+  resourceType: "network" | "volume",
+): Promise<ManagedNamedResource[]> {
+  const result = await runRequiredDockerCommand(runner, [
+    resourceType,
+    "ls",
+    "--filter",
+    `label=${managedLabel}`,
+    "--format",
+    `{{.Name}}\t{{.Label "${runIdLabelName}"}}`,
+  ]);
+
+  return result.stdout
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== "")
+    .map((line) => {
+      const [name, runId] = line.split("\t");
+
+      if (name === undefined) {
+        throw new Error(`Unexpected docker ${resourceType} ls output: ${line}`);
+      }
+
+      return {
+        name,
+        runId: runId === undefined || runId === "" ? null : runId,
+      };
+    });
+}
+
+async function runRequiredDockerCommand(
+  runner: DockerCommandRunner,
+  args: string[],
+): Promise<DockerCommandResult> {
+  const result = await runner.run(args);
+
+  if (result.exitCode !== 0) {
+    throw new Error(`Docker command failed: docker ${args.join(" ")}\n${result.stderr}`);
+  }
+
+  return result;
 }

--- a/test/docker.test.ts
+++ b/test/docker.test.ts
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  cleanupManagedDockerResources,
   createDockerSandbox,
   dockerResourceNames,
   dockerRunArgs,
   networkCreateArgs,
   volumeCreateArgs,
+  type DockerCommandResult,
+  type DockerCommandRunner,
   type DockerRunOptions,
   type DockerRunner,
 } from "../src/docker.js";
@@ -19,6 +22,30 @@ function recordingRunner(): DockerRunner & {
     calls,
     async run(args: string[], options: DockerRunOptions = {}): Promise<void> {
       calls.push({ args, options });
+    },
+  };
+}
+
+function result(stdout = "", exitCode = 0, stderr = ""): DockerCommandResult {
+  return { exitCode, stdout, stderr };
+}
+
+function recordingCommandRunner(results: DockerCommandResult[]): DockerCommandRunner & {
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+
+  return {
+    calls,
+    async run(args: string[]): Promise<DockerCommandResult> {
+      calls.push(args);
+      const next = results.shift();
+
+      if (next === undefined) {
+        throw new Error(`Unexpected docker command: docker ${args.join(" ")}`);
+      }
+
+      return next;
     },
   };
 }
@@ -153,4 +180,104 @@ test("createDockerSandbox can attach agent commands to an externally managed ser
     false,
   );
   assert.deepEqual(runner.calls[3]?.args, ["volume", "rm", "codex-cage-run-1-workspace"]);
+});
+
+test("cleanupManagedDockerResources removes stopped resources and skips active runs by default", async () => {
+  const runner = recordingCommandRunner([
+    result("active1\trunning\trun-active\nstopped1\texited\trun-stale\n"),
+    result("codex-cage-run-active\trun-active\ncodex-cage-run-stale\trun-stale\n"),
+    result(
+      "codex-cage-run-active-workspace\trun-active\ncodex-cage-run-stale-workspace\trun-stale\n",
+    ),
+    result(),
+    result(),
+    result(),
+  ]);
+
+  const report = await cleanupManagedDockerResources({ runner });
+
+  assert.deepEqual(report, {
+    containers: ["stopped1"],
+    networks: ["codex-cage-run-stale"],
+    volumes: ["codex-cage-run-stale-workspace"],
+    skippedActiveRunIds: ["run-active"],
+  });
+  assert.deepEqual(runner.calls, [
+    [
+      "ps",
+      "--all",
+      "--filter",
+      "label=codex-cage.managed=true",
+      "--format",
+      '{{.ID}}\t{{.State}}\t{{.Label "codex-cage.run_id"}}',
+    ],
+    [
+      "network",
+      "ls",
+      "--filter",
+      "label=codex-cage.managed=true",
+      "--format",
+      '{{.Name}}\t{{.Label "codex-cage.run_id"}}',
+    ],
+    [
+      "volume",
+      "ls",
+      "--filter",
+      "label=codex-cage.managed=true",
+      "--format",
+      '{{.Name}}\t{{.Label "codex-cage.run_id"}}',
+    ],
+    ["rm", "stopped1"],
+    ["network", "rm", "codex-cage-run-stale"],
+    ["volume", "rm", "codex-cage-run-stale-workspace"],
+  ]);
+});
+
+test("cleanupManagedDockerResources --all removes active managed resources explicitly", async () => {
+  const runner = recordingCommandRunner([
+    result("active1\trunning\trun-active\nstopped1\texited\trun-stale\n"),
+    result("codex-cage-run-active\trun-active\ncodex-cage-run-stale\trun-stale\n"),
+    result(
+      "codex-cage-run-active-workspace\trun-active\ncodex-cage-run-stale-workspace\trun-stale\n",
+    ),
+    result(),
+    result(),
+    result(),
+  ]);
+
+  const report = await cleanupManagedDockerResources({ all: true, runner });
+
+  assert.deepEqual(report, {
+    containers: ["active1", "stopped1"],
+    networks: ["codex-cage-run-active", "codex-cage-run-stale"],
+    volumes: ["codex-cage-run-active-workspace", "codex-cage-run-stale-workspace"],
+    skippedActiveRunIds: [],
+  });
+  assert.deepEqual(runner.calls.at(3), ["rm", "--force", "active1", "stopped1"]);
+  assert.deepEqual(runner.calls.at(4), [
+    "network",
+    "rm",
+    "codex-cage-run-active",
+    "codex-cage-run-stale",
+  ]);
+  assert.deepEqual(runner.calls.at(5), [
+    "volume",
+    "rm",
+    "codex-cage-run-active-workspace",
+    "codex-cage-run-stale-workspace",
+  ]);
+});
+
+test("cleanupManagedDockerResources reports no-op cleanup without touching artifacts", async () => {
+  const runner = recordingCommandRunner([result(), result(), result()]);
+
+  const report = await cleanupManagedDockerResources({ runner });
+
+  assert.deepEqual(report, {
+    containers: [],
+    networks: [],
+    volumes: [],
+    skippedActiveRunIds: [],
+  });
+  assert.equal(runner.calls.length, 3);
 });


### PR DESCRIPTION
## Summary
- Implement cleanup of Docker resources labeled as managed by Codex Cage.
- Default cleanup removes stopped managed containers and run resources that do not have active managed containers.
- Add cleanup --all behavior to explicitly force-remove active managed containers plus their networks and volumes.
- Wire codex-cage cleanup to print removed containers, networks, volumes, and skipped active runs.
- Document cleanup behavior in README.

## Validation
- npm run typecheck
- npm test
- npm run format
- npm --cache /tmp/codex-cage-npm-cache exec -- codex-cage --help
- npm --cache /tmp/codex-cage-npm-cache pack --dry-run

Closes #12