### PR TITLE
Add docs and QA harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Codex Cage is a lightweight CLI for running Codex against issue-driven work in an isolated Docker workspace. The project is currently in early scaffold form: the CLI exists, `init` works, and the later run/orchestration commands are intentionally stubbed until their implementation slices land.
 
-Full setup, token, configuration, security, and QA details live in [docs/mvp-workflow.md](docs/mvp-workflow.md).
+Full setup, token, configuration, security, and QA details live in [docs/workflow.md](docs/workflow.md).
 
 ## Current Commands
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Codex Cage is a lightweight CLI for running Codex against issue-driven work in an isolated Docker workspace. The project is currently in early scaffold form: the CLI exists, `init` works, and the later run/orchestration commands are intentionally stubbed until their implementation slices land.
 
+Full setup, token, configuration, security, and QA details live in [docs/mvp-workflow.md](docs/mvp-workflow.md).
+
 ## Current Commands
 
 ```bash
@@ -128,6 +130,7 @@ Cleanup removes Docker resources labeled as managed by Codex Cage. By default it
 npm install
 npm run typecheck
 npm test
+npm run qa
 npm run format
 ```
 

--- a/docs/mvp-workflow.md
+++ b/docs/mvp-workflow.md
@@ -1,0 +1,188 @@
+# Codex Cage MVP Workflow
+
+Codex Cage runs issue-driven Codex work in Docker-owned workspaces. The CLI is built as a set of small orchestration slices: config/init, issue context, repo auth, Docker sandboxing, Compose services, guards, review, publishing, and cleanup.
+
+The `run` command is currently routed in the CLI but not wired into one end-to-end orchestrator yet. The command examples below define the intended MVP interface and are covered by local fake-integration QA so the flow can be validated without real Codex or GitHub calls.
+
+## Install
+
+From this repository:
+
+```bash
+npm install
+npm run build
+npm install -g .
+codex-cage --help
+```
+
+For a one-off local invocation:
+
+```bash
+npm run build
+npm exec -- codex-cage --help
+```
+
+Node.js `>=22` is required.
+
+## Token Setup
+
+Create `.codex-cage.env` in the host repo where you run Codex Cage:
+
+```dotenv
+OPENAI_API_KEY=...
+GITHUB_TOKEN=...
+LINEAR_API_KEY=...
+```
+
+`LINEAR_API_KEY` is required only for Linear issue URLs. `.codex-cage.env` is ignored by `codex-cage init` and must not be committed.
+
+### GitHub Token Permissions
+
+Use a fine-grained GitHub token scoped to the target repository.
+
+Required repository permissions:
+
+- **Contents: Read and write** for clone, branch push, and commit publishing.
+- **Issues: Read-only** for GitHub issue context.
+- **Pull requests: Read and write** for PR creation.
+- **Metadata: Read-only** is required by GitHub for repository access.
+
+No organization-wide token is required for the MVP.
+
+## Initialize A Target Repo
+
+Run this in the target repository:
+
+```bash
+codex-cage init
+```
+
+This creates:
+
+- `.codex-cage.yml`
+- `.codex-cage.env.example`
+- `.gitignore` entries for `.codex-cage.env`, run artifacts, and SQLite metadata
+
+Use a custom Dockerfile when the target repository needs system packages:
+
+```bash
+codex-cage init --dockerfile
+```
+
+## `.codex-cage.yml` Schema
+
+```yaml
+setup:
+  - npm install
+
+verify:
+  - npm test
+
+services:
+  compose: docker-compose.yml
+  ready:
+    - pg_isready -h db -U postgres
+
+agent:
+  model: gpt-5.4
+  max_iterations: 5
+  max_review_cycles: 2
+
+timeouts:
+  total_minutes: 90
+  command_minutes: 20
+  idle_minutes: 10
+
+pr:
+  draft: false
+
+git:
+  base: main
+  author_name: Codex Cage
+  author_email: codex-cage@users.noreply.github.com
+
+issue:
+  comments: 10
+
+guards:
+  max_secret_fix_attempts: 2
+```
+
+`verify` must contain at least one command. The generated default intentionally fails until replaced with the target repo's real validation command.
+
+## Running GitHub Issues
+
+Intended MVP command shape:
+
+```bash
+codex-cage run --issue https://github.com/OWNER/REPO/issues/123
+```
+
+GitHub issue URLs infer the target repository. If the current directory has a different GitHub origin, Codex Cage fails unless `--repo OWNER/REPO` is passed explicitly.
+
+Successful runs create one branch, one commit, one push, and one ready PR. GitHub issue PR bodies include a closing keyword such as `Closes #123`, so GitHub closes the issue only after PR merge.
+
+## Running Linear Issues
+
+Intended MVP command shape:
+
+```bash
+codex-cage run --issue https://linear.app/ORG/issue/ENG-123/title --repo OWNER/REPO
+```
+
+Linear issue URLs provide issue context but do not infer a GitHub repo. Use `--repo`, or run from a directory with a GitHub `origin` remote. Codex Cage links the Linear issue in the PR body but does not mutate Linear.
+
+## Security Boundaries
+
+Codex Cage is designed so agent code runs in Docker-managed resources, not the host working tree.
+
+Current boundaries:
+
+- No host working tree bind mount.
+- No Docker socket mount.
+- No host SSH config mount.
+- No GitHub CLI config mount.
+- No host port publishing by default.
+- Agent commands run as the non-root `agent` user.
+- Secrets are passed as process environment and redacted from logs.
+- Diff guards block injected secrets, high-confidence token patterns, private keys, and sensitive auth files.
+- Compose services are orchestrator-managed and per-run isolated by project name.
+
+Non-goals:
+
+- Codex Cage is not a general untrusted-code sandbox.
+- Codex Cage does not guarantee protection against Docker daemon or kernel vulnerabilities.
+- Codex Cage does not manage cloud IAM or external secret rotation.
+- Codex Cage does not update Linear issues in the MVP.
+
+## Cleanup
+
+```bash
+codex-cage cleanup
+codex-cage cleanup --all
+```
+
+Default cleanup removes stopped managed containers plus networks and volumes for runs without active managed containers. `--all` explicitly removes active managed containers and all managed networks and volumes.
+
+Cleanup does not delete `.codex-cage/runs` artifacts or `.codex-cage/codex-cage.sqlite`.
+
+## Local QA
+
+Run all checks:
+
+```bash
+npm run typecheck
+npm test
+npm run qa
+npm run format
+```
+
+`npm run qa` executes a fake integration harness for the main MVP outcomes:
+
+- success
+- verify failure
+- review blocking
+- secret guard failure
+- no-op diff
+
+The QA harness avoids real Codex, Docker, GitHub, and Linear calls by using injected fake runners.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,8 +1,8 @@
-# Codex Cage MVP Workflow
+# Codex Cage Workflow
 
 Codex Cage runs issue-driven Codex work in Docker-owned workspaces. The CLI is built as a set of small orchestration slices: config/init, issue context, repo auth, Docker sandboxing, Compose services, guards, review, publishing, and cleanup.
 
-The `run` command is currently routed in the CLI but not wired into one end-to-end orchestrator yet. The command examples below define the intended MVP interface and are covered by local fake-integration QA so the flow can be validated without real Codex or GitHub calls.
+The `run` command is currently routed in the CLI but not wired into one end-to-end orchestrator yet. The command examples below define the intended interface and are covered by local fake-integration QA so the flow can be validated without real Codex or GitHub calls.
 
 ## Install
 
@@ -47,7 +47,7 @@ Required repository permissions:
 - **Pull requests: Read and write** for PR creation.
 - **Metadata: Read-only** is required by GitHub for repository access.
 
-No organization-wide token is required for the MVP.
+No organization-wide token is required.
 
 ## Initialize A Target Repo
 
@@ -112,7 +112,7 @@ guards:
 
 ## Running GitHub Issues
 
-Intended MVP command shape:
+Intended command shape:
 
 ```bash
 codex-cage run --issue https://github.com/OWNER/REPO/issues/123
@@ -124,7 +124,7 @@ Successful runs create one branch, one commit, one push, and one ready PR. GitHu
 
 ## Running Linear Issues
 
-Intended MVP command shape:
+Intended command shape:
 
 ```bash
 codex-cage run --issue https://linear.app/ORG/issue/ENG-123/title --repo OWNER/REPO
@@ -153,7 +153,7 @@ Non-goals:
 - Codex Cage is not a general untrusted-code sandbox.
 - Codex Cage does not guarantee protection against Docker daemon or kernel vulnerabilities.
 - Codex Cage does not manage cloud IAM or external secret rotation.
-- Codex Cage does not update Linear issues in the MVP.
+- Codex Cage does not update Linear issues.
 
 ## Cleanup
 
@@ -177,7 +177,7 @@ npm run qa
 npm run format
 ```
 
-`npm run qa` executes a fake integration harness for the main MVP outcomes:
+`npm run qa` executes a fake integration harness for the main outcomes:
 
 - success
 - verify failure

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
     "codex-cage": "./dist/src/cli.js"
   },
   "files": [
-    "dist/src"
+    "dist/src",
+    "docs"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "npm run build && node --test \"dist/test/**/*.test.js\"",
+    "qa": "npm run build && node --test \"dist/test/qa.test.js\"",
     "lint": "npm run typecheck",
     "format": "prettier --check ."
   },

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -17,7 +17,7 @@ function runCli(args: string[], cwd?: string) {
   });
 }
 
-test("root help lists MVP commands", () => {
+test("root help lists commands", () => {
   const result = runCli(["--help"]);
 
   assert.equal(result.status, 0);
@@ -28,7 +28,7 @@ test("root help lists MVP commands", () => {
   assert.match(result.stdout, /\bcleanup\b/);
 });
 
-test("command help is available for MVP commands", () => {
+test("command help is available for commands", () => {
   const commands = [
     ["init", "--help"],
     ["run", "--help"],

--- a/test/qa.test.ts
+++ b/test/qa.test.ts
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { IssueContext } from "../src/issue.js";
+import { assertNoGuardViolations, scanDiffForGuardViolations } from "../src/guards.js";
+import {
+  NoDiffError,
+  publishSuccessfulRun,
+  type CommandResult,
+  type CommandRunner,
+  type PublishMetadata,
+} from "../src/publish.js";
+import type { GithubRepo } from "../src/repo.js";
+import { runIndependentReview, type ReviewAgentRunner } from "../src/review.js";
+
+type QaScenario =
+  | "success"
+  | "verify_failed"
+  | "review_blocking"
+  | "secret_guard_failed"
+  | "no_diff";
+
+type QaResult = {
+  scenario: QaScenario;
+  status: "succeeded" | "failed";
+  failureCode: string | null;
+  prUrl: string | null;
+};
+
+type FakeRunInput = {
+  scenario: QaScenario;
+};
+
+type RecordedCall = {
+  args: string[];
+};
+
+const repo: GithubRepo = {
+  owner: "jhowliu",
+  name: "codex-cage",
+  fullName: "jhowliu/codex-cage",
+};
+
+const issue: IssueContext = {
+  source: "github",
+  url: "https://github.com/jhowliu/codex-cage/issues/13",
+  identifier: "#13",
+  title: "Docs and QA",
+  body: "Document the MVP workflow and add QA coverage.",
+  comments: [],
+  inferredRepo: "jhowliu/codex-cage",
+};
+
+const metadata: PublishMetadata = {
+  runId: "run-qa-1234567890",
+  summary: "Fake QA implementation completed.",
+  verification: ["fake verify passed"],
+  reviewStatus: "Independent review passed.",
+  risks: [],
+};
+
+function commandResult(stdout = "", exitCode = 0, stderr = ""): CommandResult {
+  return { exitCode, stdout, stderr };
+}
+
+function recordingCommandRunner(results: CommandResult[]): CommandRunner & {
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+
+  return {
+    calls,
+    async run(args): Promise<CommandResult> {
+      calls.push({ args });
+      const next = results.shift();
+
+      if (next === undefined) {
+        throw new Error(`Unexpected command: ${args.join(" ")}`);
+      }
+
+      return next;
+    },
+  };
+}
+
+function reviewRunner(report: unknown): ReviewAgentRunner {
+  return {
+    async run(): Promise<string> {
+      return JSON.stringify(report);
+    },
+  };
+}
+
+async function runFakeQaScenario(input: FakeRunInput): Promise<QaResult> {
+  const diff =
+    input.scenario === "no_diff"
+      ? ""
+      : `diff --git a/src/app.ts b/src/app.ts
+@@ -1 +1,2 @@
+ export const ok = true;
++export const changed = true;
+`;
+
+  if (input.scenario === "verify_failed") {
+    return {
+      scenario: input.scenario,
+      status: "failed",
+      failureCode: "verify_failed",
+      prUrl: null,
+    };
+  }
+
+  const guardedDiff =
+    input.scenario === "secret_guard_failed"
+      ? `diff --git a/src/app.ts b/src/app.ts
+@@ -1 +1,2 @@
+ export const ok = true;
++export const token = "known-secret-value";
+`
+      : diff;
+  const guardViolations = scanDiffForGuardViolations(guardedDiff, {
+    injectedSecrets: { GITHUB_TOKEN: "known-secret-value" },
+  });
+
+  try {
+    assertNoGuardViolations(guardViolations);
+  } catch {
+    return {
+      scenario: input.scenario,
+      status: "failed",
+      failureCode: "secret_guard_failed",
+      prUrl: null,
+    };
+  }
+
+  const review = await runIndependentReview({
+    cwd: "/repo",
+    model: "gpt-5.4",
+    cycle: 0,
+    maxReviewCycles: 0,
+    issueContext: issue.body,
+    diff,
+    verificationSummary: "fake verify passed",
+    resultMetadata: { runId: metadata.runId },
+    readCurrentDiff: async () => diff,
+    runner: reviewRunner(
+      input.scenario === "review_blocking"
+        ? {
+            decision: "blocking",
+            summary: "Blocking review.",
+            findings: [
+              {
+                severity: "blocking",
+                message: "Missing required behavior.",
+                path: "src/app.ts",
+                line: 2,
+              },
+            ],
+          }
+        : {
+            decision: "pass",
+            summary: "No blocking issues.",
+            findings: [],
+          },
+    ),
+  });
+
+  if (review.nextAction.action === "fail") {
+    return {
+      scenario: input.scenario,
+      status: "failed",
+      failureCode: review.nextAction.failureCode,
+      prUrl: null,
+    };
+  }
+
+  const git = recordingCommandRunner(
+    input.scenario === "no_diff"
+      ? [commandResult("")]
+      : [
+          commandResult(" M src/app.ts\n"),
+          commandResult("", 1),
+          commandResult("", 1),
+          commandResult(),
+          commandResult(),
+          commandResult(),
+          commandResult(),
+          commandResult(),
+          commandResult(),
+        ],
+  );
+  const gh = recordingCommandRunner([
+    commandResult("https://github.com/jhowliu/codex-cage/pull/99\n"),
+  ]);
+
+  try {
+    const publish = await publishSuccessfulRun({
+      cwd: "/repo",
+      repo,
+      issue,
+      baseBranch: "main",
+      authorName: "Codex Cage",
+      authorEmail: "codex-cage@users.noreply.github.com",
+      metadata,
+      git,
+      gh,
+    });
+
+    return {
+      scenario: input.scenario,
+      status: "succeeded",
+      failureCode: null,
+      prUrl: publish.prUrl,
+    };
+  } catch (error) {
+    if (error instanceof NoDiffError) {
+      return {
+        scenario: input.scenario,
+        status: "failed",
+        failureCode: "no_diff",
+        prUrl: null,
+      };
+    }
+
+    throw error;
+  }
+}
+
+test("QA harness covers success, verify failure, review blocking, secret guard failure, and no-op diff", async () => {
+  const scenarios: QaScenario[] = [
+    "success",
+    "verify_failed",
+    "review_blocking",
+    "secret_guard_failed",
+    "no_diff",
+  ];
+  const results = await Promise.all(
+    scenarios.map((scenario) => runFakeQaScenario({ scenario })),
+  );
+
+  assert.deepEqual(results, [
+    {
+      scenario: "success",
+      status: "succeeded",
+      failureCode: null,
+      prUrl: "https://github.com/jhowliu/codex-cage/pull/99",
+    },
+    {
+      scenario: "verify_failed",
+      status: "failed",
+      failureCode: "verify_failed",
+      prUrl: null,
+    },
+    {
+      scenario: "review_blocking",
+      status: "failed",
+      failureCode: "review_blocking",
+      prUrl: null,
+    },
+    {
+      scenario: "secret_guard_failed",
+      status: "failed",
+      failureCode: "secret_guard_failed",
+      prUrl: null,
+    },
+    {
+      scenario: "no_diff",
+      status: "failed",
+      failureCode: "no_diff",
+      prUrl: null,
+    },
+  ]);
+});

--- a/test/qa.test.ts
+++ b/test/qa.test.ts
@@ -45,7 +45,7 @@ const issue: IssueContext = {
   url: "https://github.com/jhowliu/codex-cage/issues/13",
   identifier: "#13",
   title: "Docs and QA",
-  body: "Document the MVP workflow and add QA coverage.",
+  body: "Document the workflow and add QA coverage.",
   comments: [],
   inferredRepo: "jhowliu/codex-cage",
 };


### PR DESCRIPTION
## Summary
- Add workflow docs for install, token setup, init, config schema, GitHub and Linear issue command shapes, security boundaries, cleanup, and local QA.
- Add a local fake integration QA harness covering success, verify failure, review blocking, secret guard failure, and no-op diff without real Codex/GitHub/Linear calls.
- Add npm run qa and include docs in package files so README package links resolve.
- Rename the workflow doc to docs/workflow.md and remove MVP wording.

## Validation
- npm run typecheck
- npm test
- npm run qa
- npm run format
- npm --cache /tmp/codex-cage-npm-cache exec -- codex-cage --help
- npm --cache /tmp/codex-cage-npm-cache pack --dry-run

Closes #13