### PR TITLE
Wire run command orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codex Cage
 
-Codex Cage is a lightweight CLI for running Codex against issue-driven work in an isolated Docker workspace. The project is currently in early scaffold form: the CLI exists, `init` works, and the later run/orchestration commands are intentionally stubbed until their implementation slices land.
+Codex Cage is a lightweight CLI for running Codex against issue-driven work in an isolated Docker workspace. The CLI can initialize target repos, run the issue-driven orchestration loop, inspect local run metadata, and clean up managed Docker resources.
 
 Full setup, token, configuration, security, and QA details live in [docs/workflow.md](docs/workflow.md).
 
@@ -19,10 +19,10 @@ codex-cage cleanup
 Implemented commands:
 
 - `init`
+- `run`
 - `runs list`
 - `runs show`
-
-Other commands are routed and documented in help output, but return a not-implemented error.
+- `cleanup`
 
 ## Initialize a Target Repo
 
@@ -52,6 +52,14 @@ codex-cage runs show <run-id>
 ```
 
 Run metadata is stored in `.codex-cage/codex-cage.sqlite`. Large artifacts such as logs, patches, issue payloads, and summaries are stored under `.codex-cage/runs/<run-id>` rather than inside SQLite.
+
+## Run an Issue
+
+```bash
+codex-cage run --issue https://github.com/OWNER/REPO/issues/123
+```
+
+The `run` command reads `.codex-cage.yml` and `.codex-cage.env`, fetches issue context, resolves the target repo, creates a Docker workspace, starts configured Compose services, runs Codex implementation iterations, verifies configured commands, scans the diff for secrets, runs independent review, and publishes a PR when all gates pass.
 
 ## Issue Context
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -2,7 +2,7 @@
 
 Codex Cage runs issue-driven Codex work in Docker-owned workspaces. The CLI is built as a set of small orchestration slices: config/init, issue context, repo auth, Docker sandboxing, Compose services, guards, review, publishing, and cleanup.
 
-The `run` command is currently routed in the CLI but not wired into one end-to-end orchestrator yet. The command examples below define the intended interface and are covered by local fake-integration QA so the flow can be validated without real Codex or GitHub calls.
+The `run` command wires those slices into one orchestration loop. It fetches issue context, clones into a Docker volume, runs setup and verification commands, feeds failures back into Codex for bounded retries, runs an independent read-only review, blocks secret-bearing diffs, and publishes a PR only after all gates pass.
 
 ## Install
 
@@ -112,8 +112,6 @@ guards:
 
 ## Running GitHub Issues
 
-Intended command shape:
-
 ```bash
 codex-cage run --issue https://github.com/OWNER/REPO/issues/123
 ```
@@ -123,8 +121,6 @@ GitHub issue URLs infer the target repository. If the current directory has a di
 Successful runs create one branch, one commit, one push, and one ready PR. GitHub issue PR bodies include a closing keyword such as `Closes #123`, so GitHub closes the issue only after PR merge.
 
 ## Running Linear Issues
-
-Intended command shape:
 
 ```bash
 codex-cage run --issue https://linear.app/ORG/issue/ENG-123/title --repo OWNER/REPO

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,16 +1,9 @@
 import { Command } from "commander";
 import { cleanupManagedDockerResources, type CleanupDockerReport } from "./docker.js";
 import { initProject } from "./init.js";
+import { runCodexCage } from "./run.js";
 import { openRunStore } from "./state.js";
 import { readPackageVersion } from "./version.js";
-
-type CommandHandler = () => Promise<void> | void;
-
-const notImplemented =
-  (commandName: string): CommandHandler =>
-  () => {
-    throw new Error(`${commandName} is not implemented yet.`);
-  };
 
 export function createCli(): Command {
   const program = new Command();
@@ -46,7 +39,36 @@ export function createCli(): Command {
     .option("--base <branch>", "base branch override")
     .option("--model <model>", "Codex model override")
     .option("--draft", "create a draft pull request")
-    .action(notImplemented("run"));
+    .action(
+      async (options: {
+        issue: string;
+        repo?: string;
+        base?: string;
+        model?: string;
+        draft?: boolean;
+      }) => {
+        const result = await runCodexCage(
+          removeUndefinedProperties({
+            issueUrl: options.issue,
+            repo: options.repo,
+            base: options.base,
+            model: options.model,
+            draft: options.draft,
+          }),
+        );
+
+        console.log(`Run: ${result.runId}`);
+        console.log(`Status: ${result.status}`);
+
+        if (result.failureCode !== null) {
+          console.log(`Failure: ${result.failureCode}`);
+        }
+
+        if (result.prUrl !== null) {
+          console.log(`PR: ${result.prUrl}`);
+        }
+      },
+    );
 
   const runs = program.command("runs").description("Inspect prior Codex Cage runs.");
 
@@ -134,6 +156,14 @@ export function createCli(): Command {
     });
 
   return program;
+}
+
+function removeUndefinedProperties<TValue extends Record<string, unknown>>(
+  value: TValue,
+): TValue {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as TValue;
 }
 
 function formatCleanupReport(report: CleanupDockerReport): string {

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,0 +1,871 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { execa } from "execa";
+import YAML from "yaml";
+import {
+  createComposeProject,
+  hasComposeServices,
+  type ComposeProject,
+} from "./compose.js";
+import { parseCodexCageConfig, type CodexCageConfig } from "./config.js";
+import {
+  createDockerSandbox,
+  dockerRunArgs,
+  type DockerSandbox,
+  type DockerSandboxOptions,
+} from "./docker.js";
+import {
+  assertNoGuardViolations,
+  createSecretRedactor,
+  guardAttemptDecision,
+  GuardViolationError,
+  readCodexCageEnv,
+  scanDiffForGuardViolations,
+} from "./guards.js";
+import { fetchIssueContext, type IssueContext } from "./issue.js";
+import {
+  NoDiffError,
+  publishSuccessfulRun,
+  type CommandResult,
+  type CommandRunner,
+} from "./publish.js";
+import {
+  createAuthenticatedRepo,
+  resolveTargetRepo,
+  type AuthenticatedRepo,
+  type RepoResolution,
+} from "./repo.js";
+import {
+  runIndependentReview,
+  type ReviewAgentRunner,
+  ReviewModifiedDiffError,
+} from "./review.js";
+import {
+  openRunStore,
+  type FailureCode,
+  type PhaseName,
+  type RunStore,
+} from "./state.js";
+import { generateBranchName } from "./publish.js";
+
+export type RunCommandOptions = {
+  cwd?: string;
+  issueUrl: string;
+  repo?: string | undefined;
+  base?: string | undefined;
+  model?: string | undefined;
+  draft?: boolean | undefined;
+};
+
+export type RunCodexCageResult = {
+  runId: string;
+  status: "succeeded" | "failed";
+  failureCode: FailureCode | null;
+  prUrl: string | null;
+};
+
+export type ShellRunner = {
+  run(command: string): Promise<CommandResult>;
+};
+
+export type RunCodexCageDependencies = {
+  fetchIssueContext?: typeof fetchIssueContext;
+  resolveTargetRepo?: typeof resolveTargetRepo;
+  createAuthenticatedRepo?: typeof createAuthenticatedRepo;
+  readEnv?: typeof readCodexCageEnv;
+  openRunStore?: typeof openRunStore;
+  createDockerSandbox?: (options: DockerSandboxOptions) => DockerSandbox;
+  createShellRunner?: (
+    sandbox: DockerSandbox,
+    env: Record<string, string>,
+  ) => ShellRunner;
+  createComposeProject?: typeof createComposeProject;
+  runIndependentReview?: typeof runIndependentReview;
+  publishSuccessfulRun?: typeof publishSuccessfulRun;
+  generateRunId?: () => string;
+};
+
+type RuntimeContext = {
+  cwd: string;
+  config: CodexCageConfig;
+  configWarnings: string[];
+  secrets: Record<string, string>;
+  issue: IssueContext;
+  repoResolution: RepoResolution;
+  authenticatedRepo: AuthenticatedRepo;
+  baseBranch: string;
+  model: string;
+  draft: boolean;
+  runId: string;
+  branchName: string;
+};
+
+type PhaseBody = () => Promise<string | undefined>;
+
+const configPath = ".codex-cage.yml";
+
+export async function runCodexCage(
+  options: RunCommandOptions,
+  dependencies: RunCodexCageDependencies = {},
+): Promise<RunCodexCageResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const context = await prepareRuntimeContext(cwd, options, dependencies);
+  const openStore = dependencies.openRunStore ?? openRunStore;
+  const createSandbox = dependencies.createDockerSandbox ?? createDockerSandbox;
+  const makeShellRunner = dependencies.createShellRunner ?? createDockerShellRunner;
+  const makeComposeProject = dependencies.createComposeProject ?? createComposeProject;
+  const review = dependencies.runIndependentReview ?? runIndependentReview;
+  const publish = dependencies.publishSuccessfulRun ?? publishSuccessfulRun;
+  const redactor = createSecretRedactor(context.secrets);
+  const store = await openStore(cwd);
+  let sandbox: DockerSandbox | null = null;
+  let shell: ShellRunner | null = null;
+  let compose: ComposeProject | null = null;
+
+  try {
+    await store.createRun({
+      id: context.runId,
+      issueUrl: context.issue.url,
+      issueKey: context.issue.identifier,
+      repo: context.repoResolution.repo.fullName,
+      baseBranch: context.baseBranch,
+      branch: context.branchName,
+    });
+    await writeJsonArtifact(store, context.runId, "issue.json", context.issue);
+    await writeJsonArtifact(store, context.runId, "resolved-config.json", {
+      config: context.config,
+      warnings: context.configWarnings,
+      repoSource: context.repoResolution.source,
+    });
+
+    await runPhase(store, context.runId, "preflight", async () => {
+      return [
+        `Issue: ${context.issue.identifier} ${context.issue.title}`,
+        `Repo: ${context.repoResolution.repo.fullName}`,
+        `Base: ${context.baseBranch}`,
+        `Branch: ${context.branchName}`,
+      ].join("\n");
+    });
+
+    if (hasComposeServices(context.config.services)) {
+      const composeFile = context.config.services.compose;
+
+      if (composeFile === null) {
+        throw new RunFailureError("invalid_config", "Compose file is not configured.");
+      }
+
+      compose = makeComposeProject({
+        runId: context.runId,
+        composeFile: resolve(cwd, composeFile),
+        projectDirectory: cwd,
+        readyCommands: context.config.services.ready,
+      });
+      try {
+        await runPhase(store, context.runId, "setup", async () => {
+          await compose?.up();
+          await compose?.waitUntilReady();
+          return "Compose services are ready.";
+        });
+      } catch (error) {
+        throw new RunFailureError("setup_failed", formatError(error));
+      }
+    }
+
+    const sandboxOptions: DockerSandboxOptions = {
+      runId: context.runId,
+      cloneUrl: context.authenticatedRepo.cloneUrl,
+      env: context.secrets,
+    };
+
+    if (compose !== null) {
+      sandboxOptions.serviceNetworkName = compose.networkName;
+    }
+
+    sandbox = createSandbox(sandboxOptions);
+    shell = makeShellRunner(sandbox, context.secrets);
+    const shellRunner = shell;
+
+    await store.updateRunStatus(context.runId, { status: "cloning" });
+    await runPhase(store, context.runId, "cloning", async () => {
+      await sandbox?.create();
+      await sandbox?.cloneRepository();
+      const checkout = await requiredShell(
+        shellRunner,
+        `git fetch origin ${shellQuote(context.baseBranch)} && git checkout ${shellQuote(
+          context.baseBranch,
+        )} && git pull --ff-only origin ${shellQuote(context.baseBranch)}`,
+        redactor,
+      );
+      return checkout;
+    });
+
+    if (context.config.setup.length > 0) {
+      await store.updateRunStatus(context.runId, { status: "setup" });
+      try {
+        await runPhase(store, context.runId, "setup", async () => {
+          const logs: string[] = [];
+          for (const command of context.config.setup) {
+            logs.push(await requiredShell(shellRunner, command, redactor));
+          }
+          return logs.join("\n");
+        });
+      } catch (error) {
+        throw new RunFailureError("setup_failed", formatError(error));
+      }
+    }
+
+    const runResult = await runImplementationLoop({
+      context,
+      store,
+      shell: shellRunner,
+      redactor,
+      review,
+      publish,
+    });
+
+    return runResult;
+  } catch (error) {
+    const failureCode = failureCodeFromError(error);
+    await writeFailureSummary(store, context.runId, error);
+    await store.updateRunStatus(context.runId, {
+      status: failureCode === "secret_guard_failed" ? "guard_failed" : "failed",
+      failureCode,
+      finishedAt: new Date(),
+    });
+
+    return {
+      runId: context.runId,
+      status: "failed",
+      failureCode,
+      prUrl: null,
+    };
+  } finally {
+    await cleanupRuntime(compose, sandbox);
+    store.close();
+  }
+}
+
+async function prepareRuntimeContext(
+  cwd: string,
+  options: RunCommandOptions,
+  dependencies: RunCodexCageDependencies,
+): Promise<RuntimeContext> {
+  const configResult = await readConfig(cwd);
+  const readEnv = dependencies.readEnv ?? readCodexCageEnv;
+  const fetchContext = dependencies.fetchIssueContext ?? fetchIssueContext;
+  const resolveRepo = dependencies.resolveTargetRepo ?? resolveTargetRepo;
+  const authenticateRepo =
+    dependencies.createAuthenticatedRepo ?? createAuthenticatedRepo;
+  const secrets = await readEnv(cwd);
+  const issueOptions: Parameters<typeof fetchIssueContext>[1] = {
+    comments: configResult.config.issue.comments,
+  };
+
+  if (secrets.GITHUB_TOKEN !== undefined) {
+    issueOptions.githubToken = secrets.GITHUB_TOKEN;
+  }
+
+  if (secrets.LINEAR_API_KEY !== undefined) {
+    issueOptions.linearApiKey = secrets.LINEAR_API_KEY;
+  }
+
+  const issue = await fetchContext(options.issueUrl, issueOptions);
+  const repoInput: Parameters<typeof resolveTargetRepo>[0] = {
+    issue,
+    cwd,
+  };
+
+  if (options.repo !== undefined) {
+    repoInput.explicitRepo = options.repo;
+  }
+
+  const repoResolution = await resolveRepo(repoInput);
+  const authenticatedRepo = authenticateRepo(repoResolution.repo, secrets.GITHUB_TOKEN);
+  const baseBranch = options.base ?? configResult.config.git.base;
+  const model = options.model ?? configResult.config.agent.model;
+  const draft = options.draft ?? configResult.config.pr.draft;
+  const runId = dependencies.generateRunId?.() ?? generateRunId();
+  const branchName = generateBranchName({ issue, runId });
+
+  return {
+    cwd,
+    config: configResult.config,
+    configWarnings: configResult.warnings,
+    secrets,
+    issue,
+    repoResolution,
+    authenticatedRepo,
+    baseBranch,
+    model,
+    draft,
+    runId,
+    branchName,
+  };
+}
+
+async function readConfig(cwd: string): Promise<{
+  config: CodexCageConfig;
+  warnings: string[];
+}> {
+  let content: string;
+
+  try {
+    content = await readFile(resolve(cwd, configPath), "utf8");
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new RunFailureError("missing_config", `${configPath} was not found.`);
+    }
+
+    throw error;
+  }
+
+  try {
+    return parseCodexCageConfig(YAML.parse(content) as unknown);
+  } catch (error) {
+    throw new RunFailureError(
+      "invalid_config",
+      error instanceof Error ? error.message : "Invalid Codex Cage config.",
+    );
+  }
+}
+
+async function runImplementationLoop(input: {
+  context: RuntimeContext;
+  store: RunStore;
+  shell: ShellRunner;
+  redactor: (input: string) => string;
+  review: typeof runIndependentReview;
+  publish: typeof publishSuccessfulRun;
+}): Promise<RunCodexCageResult> {
+  const feedback: string[] = [];
+  let reviewCycle = 0;
+  let guardAttempt = 0;
+  let lastFailure: FailureCode = "verify_failed";
+
+  for (
+    let iteration = 1;
+    iteration <= input.context.config.agent.max_iterations;
+    iteration += 1
+  ) {
+    await input.store.updateRunStatus(input.context.runId, { status: "implementing" });
+    await runPhase(input.store, input.context.runId, "implement", async () => {
+      return await requiredShell(
+        input.shell,
+        codexExecCommand({
+          model: input.context.model,
+          prompt: buildImplementationPrompt({
+            context: input.context,
+            iteration,
+            feedback,
+          }),
+        }),
+        input.redactor,
+      );
+    });
+
+    await input.store.updateRunStatus(input.context.runId, { status: "verifying" });
+    const verification = await runVerificationCommands({
+      store: input.store,
+      runId: input.context.runId,
+      shell: input.shell,
+      commands: input.context.config.verify,
+      redactor: input.redactor,
+    });
+
+    if (!verification.passed) {
+      lastFailure = "verify_failed";
+      feedback.push(verification.feedback);
+      continue;
+    }
+
+    const diff = await readCurrentDiff(input.shell);
+    const violations = scanDiffForGuardViolations(diff, {
+      injectedSecrets: input.context.secrets,
+    });
+
+    try {
+      assertNoGuardViolations(violations);
+    } catch (error) {
+      if (!(error instanceof GuardViolationError)) {
+        throw error;
+      }
+
+      const decision = guardAttemptDecision({
+        attempt: guardAttempt,
+        maxAttempts: input.context.config.guards.max_secret_fix_attempts,
+      });
+
+      if (decision.action === "fail") {
+        throw new RunFailureError("secret_guard_failed", error.message);
+      }
+
+      guardAttempt = decision.nextAttempt;
+      lastFailure = "secret_guard_failed";
+      feedback.push(`Secret guard violations must be fixed:\n${error.message}`);
+      continue;
+    }
+
+    await input.store.updateRunStatus(input.context.runId, { status: "reviewing" });
+    const reviewResult = await runPhase(
+      input.store,
+      input.context.runId,
+      "review",
+      async () => {
+        const result = await input.review({
+          cwd: input.context.cwd,
+          model: input.context.model,
+          cycle: reviewCycle,
+          maxReviewCycles: input.context.config.agent.max_review_cycles,
+          issueContext: formatIssueContext(input.context.issue),
+          diff,
+          verificationSummary: verification.summary,
+          resultMetadata: {
+            runId: input.context.runId,
+            iteration,
+            repo: input.context.repoResolution.repo.fullName,
+          },
+          readCurrentDiff: async () => await readCurrentDiff(input.shell),
+          runner: reviewAgentRunner(input.shell),
+          env: input.context.secrets,
+        });
+
+        await input.store.addReviewCycle({
+          runId: input.context.runId,
+          cycle: reviewCycle,
+          decision: result.report.decision,
+          reportPath: await input.store.writeArtifact(
+            input.context.runId,
+            `review-${reviewCycle}.json`,
+            `${JSON.stringify(result.report, null, 2)}\n`,
+          ),
+        });
+
+        return {
+          log: input.redactor(JSON.stringify(result.report, null, 2)),
+          value: result,
+        };
+      },
+    );
+
+    if (reviewResult.nextAction.action === "fix") {
+      reviewCycle = reviewResult.nextAction.nextCycle;
+      lastFailure = "review_blocking";
+      feedback.push(
+        `Independent review found blocking issues:\n${reviewResult.nextAction.feedback}`,
+      );
+      continue;
+    }
+
+    if (reviewResult.nextAction.action === "fail") {
+      throw new RunFailureError("review_blocking", reviewResult.nextAction.feedback);
+    }
+
+    await input.store.updateRunStatus(input.context.runId, { status: "creating_pr" });
+    const publishResult = await runPhase(
+      input.store,
+      input.context.runId,
+      "pr",
+      async () => {
+        let result;
+
+        try {
+          result = await input.publish({
+            cwd: input.context.cwd,
+            repo: input.context.repoResolution.repo,
+            issue: input.context.issue,
+            baseBranch: input.context.baseBranch,
+            authorName: input.context.config.git.author_name,
+            authorEmail: input.context.config.git.author_email,
+            branchName: input.context.branchName,
+            draft: input.context.draft,
+            metadata: {
+              runId: input.context.runId,
+              summary: `Implemented ${input.context.issue.identifier}: ${input.context.issue.title}`,
+              verification: verification.items,
+              reviewStatus: "Independent review passed.",
+              risks: [],
+            },
+            git: shellCommandRunner(input.shell, "git"),
+            gh: shellCommandRunner(input.shell, "gh"),
+          });
+        } catch (error) {
+          if (error instanceof NoDiffError) {
+            throw error;
+          }
+
+          throw new RunFailureError("pr_failed", formatError(error));
+        }
+
+        return {
+          log: input.redactor(JSON.stringify(result, null, 2)),
+          value: result,
+        };
+      },
+    );
+
+    await writeJsonArtifact(input.store, input.context.runId, "pr.json", publishResult);
+    await input.store.writeArtifact(
+      input.context.runId,
+      "final.patch",
+      await readCurrentDiff(input.shell),
+    );
+    await input.store.writeArtifact(
+      input.context.runId,
+      "summary.md",
+      `# ${input.context.runId}\n\nPR: ${publishResult.prUrl}\n`,
+    );
+    await input.store.updateRunStatus(input.context.runId, {
+      status: "succeeded",
+      prUrl: publishResult.prUrl,
+      finishedAt: new Date(),
+    });
+
+    return {
+      runId: input.context.runId,
+      status: "succeeded",
+      failureCode: null,
+      prUrl: publishResult.prUrl,
+    };
+  }
+
+  throw new RunFailureError(lastFailure, `Exceeded max_iterations without success.`);
+}
+
+async function runVerificationCommands(input: {
+  store: RunStore;
+  runId: string;
+  shell: ShellRunner;
+  commands: string[];
+  redactor: (input: string) => string;
+}): Promise<
+  { passed: true; summary: string; items: string[] } | { passed: false; feedback: string }
+> {
+  const items: string[] = [];
+  const phase = await input.store.startPhase({
+    runId: input.runId,
+    name: "verify",
+    logPath: input.store.artifactPath(input.runId, "verify.log"),
+  });
+  const logs: string[] = [];
+
+  for (const command of input.commands) {
+    const result = await input.shell.run(command);
+    const log = formatCommandLog(command, result);
+    logs.push(log);
+
+    if (result.exitCode !== 0) {
+      const redactedLog = input.redactor(logs.join("\n"));
+      await input.store.writeArtifact(input.runId, "verify.log", redactedLog);
+      await input.store.finishPhase({
+        phaseId: phase.id,
+        status: "failed",
+        logPath: input.store.artifactPath(input.runId, "verify.log"),
+      });
+      return {
+        passed: false,
+        feedback: `Verification failed for command: ${command}\n${redactedLog}`,
+      };
+    }
+
+    items.push(`\`${command}\` passed`);
+  }
+
+  const summary = input.redactor(logs.join("\n"));
+  await input.store.writeArtifact(input.runId, "verify.log", summary);
+  await input.store.finishPhase({
+    phaseId: phase.id,
+    status: "passed",
+    logPath: input.store.artifactPath(input.runId, "verify.log"),
+  });
+
+  return {
+    passed: true,
+    summary,
+    items,
+  };
+}
+
+async function runPhase<TValue = undefined>(
+  store: RunStore,
+  runId: string,
+  name: PhaseName,
+  body: PhaseBody | (() => Promise<{ log: string; value: TValue }>),
+): Promise<TValue> {
+  const logPath = store.artifactPath(runId, `${name}.log`);
+  const phase = await store.startPhase({ runId, name, logPath });
+
+  try {
+    const result = await body();
+    const log = normalizePhaseLog(result);
+    await store.writeArtifact(runId, `${name}.log`, log);
+    await store.finishPhase({ phaseId: phase.id, status: "passed", logPath });
+    return extractPhaseValue(result);
+  } catch (error) {
+    await store.writeArtifact(runId, `${name}.log`, formatError(error));
+    await store.finishPhase({ phaseId: phase.id, status: "failed", logPath });
+    throw error;
+  }
+}
+
+function createDockerShellRunner(
+  sandbox: DockerSandbox,
+  env: Record<string, string>,
+): ShellRunner {
+  return {
+    async run(command: string): Promise<CommandResult> {
+      const result = await execa(
+        "docker",
+        dockerRunArgs({
+          image: sandbox.image,
+          networkName: sandbox.networkName,
+          volumeName: sandbox.volumeName,
+          workspacePath: sandbox.workspacePath,
+          labels: { "codex-cage.run_id": sandbox.runId },
+          env,
+          command,
+        }),
+        {
+          env,
+          reject: false,
+        },
+      );
+
+      return {
+        exitCode: result.exitCode ?? 0,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      };
+    },
+  };
+}
+
+function shellCommandRunner(shell: ShellRunner, executable: string): CommandRunner {
+  return {
+    async run(args: string[]): Promise<CommandResult> {
+      return await shell.run([executable, ...args].map(shellQuote).join(" "));
+    },
+  };
+}
+
+function reviewAgentRunner(shell: ShellRunner): ReviewAgentRunner {
+  return {
+    async run(input): Promise<string> {
+      return await requiredShell(
+        shell,
+        codexExecCommand({ model: input.model, prompt: input.prompt }),
+      );
+    },
+  };
+}
+
+async function requiredShell(
+  shell: ShellRunner,
+  command: string,
+  redactor: (input: string) => string = (input) => input,
+): Promise<string> {
+  const result = await shell.run(command);
+  const log = redactor(formatCommandLog(command, result));
+
+  if (result.exitCode !== 0) {
+    throw new Error(log);
+  }
+
+  return log;
+}
+
+async function readCurrentDiff(shell: ShellRunner): Promise<string> {
+  const result = await shell.run(
+    "git add --intent-to-add -- . && git diff --binary HEAD",
+  );
+
+  if (result.exitCode !== 0) {
+    throw new Error(formatCommandLog("git diff", result));
+  }
+
+  return result.stdout;
+}
+
+function buildImplementationPrompt(input: {
+  context: RuntimeContext;
+  iteration: number;
+  feedback: string[];
+}): string {
+  const feedback =
+    input.feedback.length === 0
+      ? "No prior feedback."
+      : input.feedback.map((item, index) => `${index + 1}. ${item}`).join("\n\n");
+
+  return `Implement the issue below inside the current repository.
+
+Rules:
+- Work only in this repository.
+- Do not commit, push, create pull requests, or write secrets.
+- Run only commands needed to implement the issue; Codex Cage will run verification separately.
+- If the issue lacks enough detail to implement safely, stop and explain the blocker.
+
+Iteration: ${input.iteration}
+Repository: ${input.context.repoResolution.repo.fullName}
+Base branch: ${input.context.baseBranch}
+
+Issue:
+${formatIssueContext(input.context.issue)}
+
+Feedback to address:
+${feedback}
+`;
+}
+
+function formatIssueContext(issue: IssueContext): string {
+  const comments =
+    issue.comments.length === 0
+      ? "No human comments included."
+      : issue.comments
+          .map((comment) => {
+            const createdAt =
+              comment.createdAt === null ? "" : ` at ${comment.createdAt}`;
+            return `- ${comment.author}${createdAt}: ${comment.body}`;
+          })
+          .join("\n");
+
+  return `URL: ${issue.url}
+Identifier: ${issue.identifier}
+Title: ${issue.title}
+
+Body:
+${issue.body}
+
+Comments:
+${comments}
+`;
+}
+
+function codexExecCommand(input: { model: string; prompt: string }): string {
+  return `codex exec --model ${shellQuote(input.model)} ${shellQuote(input.prompt)}`;
+}
+
+function generateRunId(): string {
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/[^0-9]/g, "")
+    .slice(0, 14);
+  const random = Math.random().toString(36).slice(2, 8);
+
+  return `run-${timestamp}-${random}`;
+}
+
+function failureCodeFromError(error: unknown): FailureCode {
+  if (error instanceof RunFailureError) {
+    return error.failureCode;
+  }
+
+  if (error instanceof NoDiffError) {
+    return "no_diff";
+  }
+
+  if (error instanceof ReviewModifiedDiffError) {
+    return "review_blocking";
+  }
+
+  return "internal_error";
+}
+
+class RunFailureError extends Error {
+  readonly failureCode: FailureCode;
+
+  constructor(failureCode: FailureCode, message: string) {
+    super(message);
+    this.name = "RunFailureError";
+    this.failureCode = failureCode;
+  }
+}
+
+async function cleanupRuntime(
+  compose: ComposeProject | null,
+  sandbox: DockerSandbox | null,
+): Promise<void> {
+  const errors: string[] = [];
+
+  if (compose !== null) {
+    try {
+      await compose.down();
+    } catch (error) {
+      errors.push(formatError(error));
+    }
+  }
+
+  if (sandbox !== null) {
+    try {
+      await sandbox.cleanup();
+    } catch (error) {
+      errors.push(formatError(error));
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error(`Cleanup failed:\n${errors.join("\n")}`);
+  }
+}
+
+async function writeJsonArtifact(
+  store: RunStore,
+  runId: string,
+  name: string,
+  value: unknown,
+): Promise<void> {
+  await store.writeArtifact(runId, name, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function writeFailureSummary(
+  store: RunStore,
+  runId: string,
+  error: unknown,
+): Promise<void> {
+  await store.writeArtifact(
+    runId,
+    "summary.md",
+    `# ${runId}\n\nFailure:\n\n\`\`\`\n${formatError(error)}\n\`\`\`\n`,
+  );
+}
+
+function formatCommandLog(command: string, result: CommandResult): string {
+  return [
+    `$ ${command}`,
+    `exit code: ${result.exitCode}`,
+    result.stdout.trim() === "" ? "" : `stdout:\n${result.stdout}`,
+    result.stderr.trim() === "" ? "" : `stderr:\n${result.stderr}`,
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+}
+
+function normalizePhaseLog(
+  result: Awaited<ReturnType<PhaseBody>> | { log: string },
+): string {
+  if (typeof result === "object" && result !== null && "log" in result) {
+    return result.log;
+  }
+
+  return result ?? "";
+}
+
+function extractPhaseValue<TValue>(
+  result: Awaited<ReturnType<PhaseBody>> | { log: string; value: TValue },
+): TValue {
+  if (typeof result === "object" && result !== null && "value" in result) {
+    return result.value;
+  }
+
+  return undefined as TValue;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { DockerSandbox, DockerSandboxOptions } from "../src/docker.js";
+import type { IssueContext } from "../src/issue.js";
+import type { CommandResult, PublishSuccessfulRunInput } from "../src/publish.js";
+import type { GithubRepo, RepoResolution } from "../src/repo.js";
+import type { ReviewReport, RunIndependentReviewResult } from "../src/review.js";
+import { runCodexCage, type ShellRunner } from "../src/run.js";
+import { openRunStore } from "../src/state.js";
+
+const repo: GithubRepo = {
+  owner: "jhowliu",
+  name: "codex-cage",
+  fullName: "jhowliu/codex-cage",
+};
+
+const repoResolution: RepoResolution = {
+  repo,
+  source: "issue",
+};
+
+const issue: IssueContext = {
+  source: "github",
+  url: "https://github.com/jhowliu/codex-cage/issues/26",
+  identifier: "#26",
+  title: "Wire run command",
+  body: "Connect the run command to the orchestrator.",
+  comments: [],
+  inferredRepo: repo.fullName,
+};
+
+function commandResult(stdout = "", exitCode = 0, stderr = ""): CommandResult {
+  return { exitCode, stdout, stderr };
+}
+
+async function createProject(config: string): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), "codex-cage-run-"));
+  await writeFile(join(cwd, ".codex-cage.yml"), config, "utf8");
+  return cwd;
+}
+
+function fakeSandbox(events: string[]): DockerSandbox {
+  return {
+    runId: "run-test-123",
+    image: "fake-image",
+    volumeName: "fake-volume",
+    networkName: "fake-network",
+    ownedNetworkName: "fake-network",
+    workspacePath: "/workspace",
+    async create(): Promise<void> {
+      events.push("sandbox:create");
+    },
+    async cloneRepository(): Promise<void> {
+      events.push("sandbox:clone");
+    },
+    async runCommand(): Promise<void> {
+      throw new Error("runCommand should not be used by the orchestrator.");
+    },
+    async cleanup(): Promise<void> {
+      events.push("sandbox:cleanup");
+    },
+  };
+}
+
+function shellRunner(results: Map<string, CommandResult>): ShellRunner & {
+  commands: string[];
+} {
+  const commands: string[] = [];
+
+  return {
+    commands,
+    async run(command): Promise<CommandResult> {
+      commands.push(command);
+
+      for (const [pattern, result] of results) {
+        if (command.includes(pattern)) {
+          return result;
+        }
+      }
+
+      throw new Error(`Unexpected shell command: ${command}`);
+    },
+  };
+}
+
+function passingReview(): RunIndependentReviewResult {
+  const report: ReviewReport = {
+    decision: "pass",
+    summary: "No blocking issues.",
+    findings: [],
+  };
+
+  return {
+    report,
+    nextAction: { action: "continue" },
+  };
+}
+
+test("runCodexCage executes the happy path and records a successful run", async () => {
+  const cwd = await createProject(`
+verify:
+  - npm test
+`);
+  const events: string[] = [];
+  const shell = shellRunner(
+    new Map([
+      ["git fetch origin", commandResult()],
+      ["codex exec", commandResult("implemented")],
+      ["npm test", commandResult("tests passed")],
+      [
+        "git add --intent-to-add",
+        commandResult(`diff --git a/src/app.ts b/src/app.ts
+@@ -1 +1,2 @@
+ export const ok = true;
++export const changed = true;
+`),
+      ],
+    ]),
+  );
+  const published: PublishSuccessfulRunInput[] = [];
+
+  try {
+    const result = await runCodexCage(
+      {
+        cwd,
+        issueUrl: issue.url,
+      },
+      {
+        generateRunId: () => "run-test-123",
+        readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
+        fetchIssueContext: async () => issue,
+        resolveTargetRepo: async () => repoResolution,
+        createAuthenticatedRepo: () => ({
+          repo,
+          cloneUrl:
+            "https://x-access-token:token-value@github.com/jhowliu/codex-cage.git",
+          redactedCloneUrl:
+            "https://x-access-token:[REDACTED]@github.com/jhowliu/codex-cage.git",
+        }),
+        createDockerSandbox: (_options: DockerSandboxOptions) => fakeSandbox(events),
+        createShellRunner: () => shell,
+        runIndependentReview: async () => passingReview(),
+        publishSuccessfulRun: async (input) => {
+          published.push(input);
+          return {
+            branchName: input.branchName ?? "codex-cage/gh-26-run-test",
+            commitMessage: "#26 Wire run command",
+            prTitle: "#26 Wire run command",
+            prBody: "body",
+            prUrl: "https://github.com/jhowliu/codex-cage/pull/26",
+          };
+        },
+      },
+    );
+
+    assert.deepEqual(result, {
+      runId: "run-test-123",
+      status: "succeeded",
+      failureCode: null,
+      prUrl: "https://github.com/jhowliu/codex-cage/pull/26",
+    });
+    assert.deepEqual(events, ["sandbox:create", "sandbox:clone", "sandbox:cleanup"]);
+    assert.equal(published.length, 1);
+    assert.equal(published[0]?.metadata.verification[0], "`npm test` passed");
+
+    const store = await openRunStore(cwd);
+    const details = store.getRunDetails("run-test-123");
+    store.close();
+
+    assert.equal(details.run.status, "succeeded");
+    assert.equal(details.run.prUrl, "https://github.com/jhowliu/codex-cage/pull/26");
+    assert.deepEqual(
+      details.phases.map((phase) => phase.name),
+      ["preflight", "cloning", "implement", "verify", "review", "pr"],
+    );
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("runCodexCage records verify failure after max iterations", async () => {
+  const cwd = await createProject(`
+verify:
+  - npm test
+agent:
+  max_iterations: 1
+`);
+  const events: string[] = [];
+  const shell = shellRunner(
+    new Map([
+      ["git fetch origin", commandResult()],
+      ["codex exec", commandResult("implemented")],
+      ["npm test", commandResult("", 1, "tests failed")],
+    ]),
+  );
+
+  try {
+    const result = await runCodexCage(
+      {
+        cwd,
+        issueUrl: issue.url,
+      },
+      {
+        generateRunId: () => "run-test-failed",
+        readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
+        fetchIssueContext: async () => issue,
+        resolveTargetRepo: async () => repoResolution,
+        createAuthenticatedRepo: () => ({
+          repo,
+          cloneUrl:
+            "https://x-access-token:token-value@github.com/jhowliu/codex-cage.git",
+          redactedCloneUrl:
+            "https://x-access-token:[REDACTED]@github.com/jhowliu/codex-cage.git",
+        }),
+        createDockerSandbox: () => fakeSandbox(events),
+        createShellRunner: () => shell,
+      },
+    );
+
+    assert.deepEqual(result, {
+      runId: "run-test-failed",
+      status: "failed",
+      failureCode: "verify_failed",
+      prUrl: null,
+    });
+
+    const store = await openRunStore(cwd);
+    const details = store.getRunDetails("run-test-failed");
+    store.close();
+
+    assert.equal(details.run.status, "failed");
+    assert.equal(details.run.failureCode, "verify_failed");
+    assert.equal(details.phases.at(-1)?.name, "verify");
+    assert.equal(details.phases.at(-1)?.status, "failed");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- wire codex-cage run into a Docker-backed orchestration loop
- add run state/artifact handling for preflight, clone, setup, implement, verify, review, and PR phases
- add fake-run tests for successful publishing and verify failure
- update README and workflow docs now that run is implemented

## Validation
- npm run typecheck
- npm test
- npm run qa
- npm run format
- npm --cache /tmp/codex-cage-npm-cache exec -- codex-cage --help
- npm --cache /tmp/codex-cage-npm-cache pack --dry-run