### PR TITLE
Add GHCR base image workflow

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -1,0 +1,68 @@
+name: Publish base image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_version:
+        description: Image version tag to publish.
+        required: true
+        default: "0.1.0"
+      codex_cli_version:
+        description: Exact @openai/codex version to install.
+        required: true
+        default: "0.125.0"
+  push:
+    tags:
+      - base-v*
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}/base
+  DEFAULT_CODEX_CLI_VERSION: "0.125.0"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Resolve image inputs
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "IMAGE_VERSION=${GITHUB_REF_NAME#base-v}" >> "$GITHUB_ENV"
+            echo "CODEX_CLI_VERSION=${DEFAULT_CODEX_CLI_VERSION}" >> "$GITHUB_ENV"
+          else
+            echo "IMAGE_VERSION=${{ inputs.image_version }}" >> "$GITHUB_ENV"
+            echo "CODEX_CLI_VERSION=${{ inputs.codex_cli_version }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish base image
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/base
+          file: docker/base/Dockerfile
+          push: true
+          build-args: |
+            CODEX_CLI_VERSION=${{ env.CODEX_CLI_VERSION }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
+            ${{ env.IMAGE_NAME }}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ env.IMAGE_VERSION }}
+            org.opencontainers.image.description=Codex Cage base agent image

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Codex Cage prepares disposable Docker resources per run:
 
 The sandbox runs as the non-root `agent` user, clones the target repo into the volume, and does not bind mount the host working tree, Docker socket, SSH config, GitHub CLI config, or host ports.
 
+The publishable base image is defined in `docker/base` and published to GHCR as `ghcr.io/jhowliu/codex-cage/base:<version>`. The image contains only the orchestration tools needed by Codex Cage: Node.js/npm, pinned Codex CLI, `git`, `gh`, `curl`, `jq`, certificates, OpenSSH client, and the non-root `agent` user. Target repositories should add project-specific runtimes or build tools through their own `.codex-cage/Dockerfile`.
+
 ## Compose Services
 
 Target repos can configure Docker Compose services in `.codex-cage.yml`:
@@ -139,6 +141,7 @@ npm install
 npm run typecheck
 npm test
 npm run qa
+npm run qa:image
 npm run format
 ```
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:22-bookworm
+
+ARG CODEX_CLI_VERSION=0.125.0
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    jq \
+    openssh-client \
+  && mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    > /etc/apt/sources.list.d/github-cli.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends gh \
+  && apt-get purge -y --auto-remove gnupg \
+  && npm install -g "@openai/codex@${CODEX_CLI_VERSION}" \
+  && npm cache clean --force \
+  && groupadd --gid 10001 agent \
+  && useradd --uid 10001 --gid 10001 --create-home --shell /bin/bash agent \
+  && mkdir -p /workspace \
+  && chown agent:agent /workspace \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+USER agent

--- a/docker/base/README.md
+++ b/docker/base/README.md
@@ -1,0 +1,47 @@
+# Codex Cage Base Image
+
+The base image is the minimal runtime for Codex Cage agent containers.
+
+Published image:
+
+```text
+ghcr.io/jhowliu/codex-cage/base:0.1.0
+```
+
+The CLI should use immutable version tags for reproducible runs. The `latest` tag is published only as a manual testing convenience.
+
+## Contents
+
+The image is based on `node:22-bookworm` and includes:
+
+- Node.js and npm
+- pinned `@openai/codex`
+- `git`
+- GitHub CLI `gh`
+- `curl`
+- `jq`
+- `ca-certificates`
+- `openssh-client`
+- a non-root `agent` user
+- `/workspace` owned by `agent`
+
+The image intentionally does not include Docker CLI, Python, Go, Rust, Java, native build toolchains, database clients, browser tooling, `tini`, or a custom entrypoint. Target repositories should add project-specific system dependencies in their own `.codex-cage/Dockerfile`.
+
+## Local Validation
+
+```bash
+npm run qa:image
+```
+
+This builds `codex-cage/base:local` and verifies the expected tools are available as the `agent` user.
+
+## Publishing
+
+The image publish workflow builds `docker/base/Dockerfile` and pushes:
+
+```text
+ghcr.io/jhowliu/codex-cage/base:<version>
+ghcr.io/jhowliu/codex-cage/base:latest
+```
+
+Publishing is available through manual workflow dispatch and tags shaped like `base-v0.1.0`.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -151,6 +151,26 @@ Non-goals:
 - Codex Cage does not manage cloud IAM or external secret rotation.
 - Codex Cage does not update Linear issues.
 
+## Base Image
+
+The base agent image is defined in `docker/base/Dockerfile` and published to GHCR:
+
+```text
+ghcr.io/jhowliu/codex-cage/base:0.1.0
+```
+
+The image is intentionally orchestration-only. It includes Node.js/npm, a pinned `@openai/codex` CLI, `git`, GitHub CLI `gh`, `curl`, `jq`, certificates, OpenSSH client, the non-root `agent` user, and `/workspace`. It does not include Docker CLI, Python, Go, Rust, Java, native build toolchains, database clients, browser tooling, `tini`, or a custom entrypoint.
+
+Target repositories that need language runtimes or system packages should use `codex-cage init --dockerfile` and add those dependencies in `.codex-cage/Dockerfile`.
+
+The publish workflow supports manual dispatch and tags shaped like `base-v0.1.0`. It publishes both the immutable version tag and `latest`, but runtime defaults should use version tags.
+
+Local image validation is opt-in because it requires Docker and network access:
+
+```bash
+npm run qa:image
+```
+
 ## Cleanup
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,13 +8,15 @@
   },
   "files": [
     "dist/src",
-    "docs"
+    "docs",
+    "docker/base"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "npm run build && node --test \"dist/test/**/*.test.js\"",
     "qa": "npm run build && node --test \"dist/test/qa.test.js\"",
+    "qa:image": "docker build --build-arg CODEX_CLI_VERSION=0.125.0 -t codex-cage/base:local docker/base && docker run --rm codex-cage/base:local sh -lc 'test \"$(id -un)\" = agent && node --version && npm --version && git --version && gh --version && codex --version && curl --version >/dev/null && jq --version && ssh -V'",
     "lint": "npm run typecheck",
     "format": "prettier --check ."
   },


### PR DESCRIPTION
## Summary

- add an orchestration-only Codex Cage base image under `docker/base`
- add a GHCR publish workflow for `base-v*` tags and manual dispatch
- add opt-in `npm run qa:image` validation and document the image contract

## Validation

- `npm run typecheck`
- `npm test`
- `npm run qa`
- `npm run format`
- `npm --cache /tmp/codex-cage-npm-cache pack --dry-run`
- `git diff --check`
- `npm run qa:image`

Closes #28