### PR TITLE
Support runtime image config

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,13 @@ Codex Cage prepares disposable Docker resources per run:
 
 - A labeled Docker volume for `/workspace`
 - A labeled Docker network for run-local connectivity
-- An agent container using the pinned default image `codex-cage/base:0.1.0`
+- An agent container using the pinned default image `ghcr.io/jhowliu/codex-cage/base:0.1.0`
 
 The sandbox runs as the non-root `agent` user, clones the target repo into the volume, and does not bind mount the host working tree, Docker socket, SSH config, GitHub CLI config, or host ports.
 
 The publishable base image is defined in `docker/base` and published to GHCR as `ghcr.io/jhowliu/codex-cage/base:<version>`. The image contains only the orchestration tools needed by Codex Cage: Node.js/npm, pinned Codex CLI, `git`, `gh`, `curl`, `jq`, certificates, OpenSSH client, and the non-root `agent` user. Target repositories should add project-specific runtimes or build tools through their own `.codex-cage/Dockerfile`.
+
+Runtime images are configured in `.codex-cage.yml`. If `runtime.dockerfile` is set, Codex Cage builds a labeled per-run image from that Dockerfile using `.codex-cage/` as the build context before cloning the target repository. If no Dockerfile is configured, Codex Cage uses `runtime.image`.
 
 ## Compose Services
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -83,6 +83,10 @@ services:
   ready:
     - pg_isready -h db -U postgres
 
+runtime:
+  image: ghcr.io/jhowliu/codex-cage/base:0.1.0
+  dockerfile: null
+
 agent:
   model: gpt-5.4
   max_iterations: 5
@@ -109,6 +113,8 @@ guards:
 ```
 
 `verify` must contain at least one command. The generated default intentionally fails until replaced with the target repo's real validation command.
+
+`runtime.image` accepts any valid Docker image reference and defaults to the Codex Cage GHCR base image. If `runtime.dockerfile` is set, Codex Cage builds a labeled per-run image before cloning the target repository. The first version uses `.codex-cage/` as the Docker build context, so target runtime Dockerfiles should keep package-install inputs inside that directory.
 
 ## Running GitHub Issues
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -169,6 +169,7 @@ function removeUndefinedProperties<TValue extends Record<string, unknown>>(
 function formatCleanupReport(report: CleanupDockerReport): string {
   const lines = [
     `Removed containers: ${formatRemovedResources(report.containers)}`,
+    `Removed images: ${formatRemovedResources(report.images)}`,
     `Removed networks: ${formatRemovedResources(report.networks)}`,
     `Removed volumes: ${formatRemovedResources(report.volumes)}`,
   ];
@@ -179,6 +180,7 @@ function formatCleanupReport(report: CleanupDockerReport): string {
 
   if (
     report.containers.length === 0 &&
+    report.images.length === 0 &&
     report.networks.length === 0 &&
     report.volumes.length === 0
   ) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { defaultSandboxImage } from "./docker.js";
 
 export const codexCageConfigSchema = z
   .object({
@@ -10,6 +11,12 @@ export const codexCageConfigSchema = z
         ready: z.array(z.string()).default([]),
       })
       .default(() => ({ compose: null, ready: [] })),
+    runtime: z
+      .object({
+        image: z.string().min(1).default(defaultSandboxImage),
+        dockerfile: z.string().min(1).nullable().default(null),
+      })
+      .default(() => ({ image: defaultSandboxImage, dockerfile: null })),
     agent: z
       .object({
         model: z.string().default("gpt-5.4"),
@@ -64,6 +71,7 @@ const knownTopLevelKeys = new Set([
   "setup",
   "verify",
   "services",
+  "runtime",
   "agent",
   "timeouts",
   "pr",

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -46,6 +46,21 @@ export type DockerResourceNames = {
   networkName: string;
 };
 
+export type RuntimeImageBuildOptions = {
+  runId: string;
+  dockerfilePath: string;
+  contextPath: string;
+  imageName?: string;
+  labels?: Record<string, string>;
+  runner?: DockerRunner;
+};
+
+export type RuntimeImageBuildResult = {
+  image: string;
+  dockerfilePath: string;
+  contextPath: string;
+};
+
 export type CleanupDockerOptions = {
   all?: boolean;
   runner?: DockerCommandRunner;
@@ -53,12 +68,13 @@ export type CleanupDockerOptions = {
 
 export type CleanupDockerReport = {
   containers: string[];
+  images: string[];
   networks: string[];
   volumes: string[];
   skippedActiveRunIds: string[];
 };
 
-export const defaultSandboxImage = "codex-cage/base:0.1.0";
+export const defaultSandboxImage = "ghcr.io/jhowliu/codex-cage/base:0.1.0";
 export const defaultWorkspacePath = "/workspace";
 
 const runIdLabelName = "codex-cage.run_id";
@@ -160,6 +176,33 @@ export async function cleanupDockerResources(
   await runner.run(["volume", "rm", resources.volumeName]);
 }
 
+export async function buildRuntimeImage(
+  options: RuntimeImageBuildOptions,
+): Promise<RuntimeImageBuildResult> {
+  const runner = options.runner ?? execaDockerRunner;
+  const image = options.imageName ?? runtimeImageName(options.runId);
+  const labels = {
+    [runIdLabelName]: options.runId,
+    "codex-cage.kind": "runtime-image",
+    ...options.labels,
+  };
+
+  await runner.run(
+    dockerBuildArgs({
+      image,
+      dockerfilePath: options.dockerfilePath,
+      contextPath: options.contextPath,
+      labels,
+    }),
+  );
+
+  return {
+    image,
+    dockerfilePath: options.dockerfilePath,
+    contextPath: options.contextPath,
+  };
+}
+
 export async function cleanupManagedDockerResources(
   options: CleanupDockerOptions = {},
 ): Promise<CleanupDockerReport> {
@@ -181,6 +224,7 @@ export async function cleanupManagedDockerResources(
   const volumesToRemove = (await listManagedNamedResources(runner, "volume")).filter(
     (resource) => all || resource.runId === null || !activeRunIds.has(resource.runId),
   );
+  const imagesToRemove = all ? await listManagedImages(runner) : [];
 
   if (containersToRemove.length > 0) {
     await runRequiredDockerCommand(runner, [
@@ -206,8 +250,17 @@ export async function cleanupManagedDockerResources(
     ]);
   }
 
+  if (imagesToRemove.length > 0) {
+    await runRequiredDockerCommand(runner, [
+      "image",
+      "rm",
+      ...imagesToRemove.map((image) => image.id),
+    ]);
+  }
+
   return {
     containers: containersToRemove,
+    images: imagesToRemove.map((image) => image.name),
     networks: networksToRemove.map((resource) => resource.name),
     volumes: volumesToRemove.map((resource) => resource.name),
     skippedActiveRunIds: all ? [] : [...activeRunIds].sort(),
@@ -215,19 +268,16 @@ export async function cleanupManagedDockerResources(
 }
 
 export function dockerResourceNames(runId: string): DockerResourceNames {
-  const safeRunId = runId
-    .toLowerCase()
-    .replace(/[^a-z0-9_.-]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-
-  if (safeRunId === "") {
-    throw new Error("Run id must contain at least one Docker-safe character.");
-  }
+  const safeRunId = safeDockerNameSegment(runId);
 
   return {
     volumeName: `codex-cage-${safeRunId}-workspace`,
     networkName: `codex-cage-${safeRunId}`,
   };
+}
+
+export function runtimeImageName(runId: string): string {
+  return `codex-cage/runtime-${safeDockerNameSegment(runId)}:latest`;
 }
 
 export function volumeCreateArgs(
@@ -242,6 +292,23 @@ export function networkCreateArgs(
   labels: Record<string, string>,
 ): string[] {
   return ["network", "create", ...labelArgs(labels), networkName];
+}
+
+export function dockerBuildArgs(input: {
+  image: string;
+  dockerfilePath: string;
+  contextPath: string;
+  labels: Record<string, string>;
+}): string[] {
+  return [
+    "build",
+    "--file",
+    input.dockerfilePath,
+    "--tag",
+    input.image,
+    ...labelArgs(input.labels),
+    input.contextPath,
+  ];
 }
 
 type DockerRunArgsInput = {
@@ -302,6 +369,12 @@ type ManagedNamedResource = {
   runId: string | null;
 };
 
+type ManagedImage = {
+  id: string;
+  name: string;
+  runId: string | null;
+};
+
 async function listManagedContainers(
   runner: DockerCommandRunner,
 ): Promise<ManagedContainer[]> {
@@ -327,6 +400,34 @@ async function listManagedContainers(
       return {
         id,
         state,
+        runId: runId === undefined || runId === "" ? null : runId,
+      };
+    });
+}
+
+async function listManagedImages(runner: DockerCommandRunner): Promise<ManagedImage[]> {
+  const result = await runRequiredDockerCommand(runner, [
+    "image",
+    "ls",
+    "--filter",
+    `label=${managedLabel}`,
+    "--format",
+    `{{.ID}}\t{{.Repository}}:{{.Tag}}\t{{.Label "${runIdLabelName}"}}`,
+  ]);
+
+  return result.stdout
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== "")
+    .map((line) => {
+      const [id, name, runId] = line.split("\t");
+
+      if (id === undefined || name === undefined) {
+        throw new Error(`Unexpected docker image ls output: ${line}`);
+      }
+
+      return {
+        id,
+        name,
         runId: runId === undefined || runId === "" ? null : runId,
       };
     });
@@ -373,4 +474,17 @@ async function runRequiredDockerCommand(
   }
 
   return result;
+}
+
+function safeDockerNameSegment(value: string): string {
+  const safeValue = value
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (safeValue === "") {
+    throw new Error("Value must contain at least one Docker-safe character.");
+  }
+
+  return safeValue;
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -26,6 +26,10 @@ services:
   compose: null
   ready: []
 
+runtime:
+  image: ghcr.io/jhowliu/codex-cage/base:0.1.0
+  dockerfile: null
+
 agent:
   model: gpt-5.4
   max_iterations: 5
@@ -58,7 +62,7 @@ GITHUB_TOKEN=
 LINEAR_API_KEY=
 `;
 
-const dockerfile = `FROM node:22-bookworm
+const dockerfile = `FROM ghcr.io/jhowliu/codex-cage/base:0.1.0
 
 # Add target-repo system dependencies here.
 `;

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,10 +9,12 @@ import {
 } from "./compose.js";
 import { parseCodexCageConfig, type CodexCageConfig } from "./config.js";
 import {
+  buildRuntimeImage,
   createDockerSandbox,
   dockerRunArgs,
   type DockerSandbox,
   type DockerSandboxOptions,
+  type RuntimeImageBuildResult,
 } from "./docker.js";
 import {
   assertNoGuardViolations,
@@ -75,6 +77,7 @@ export type RunCodexCageDependencies = {
   readEnv?: typeof readCodexCageEnv;
   openRunStore?: typeof openRunStore;
   createDockerSandbox?: (options: DockerSandboxOptions) => DockerSandbox;
+  buildRuntimeImage?: typeof buildRuntimeImage;
   createShellRunner?: (
     sandbox: DockerSandbox,
     env: Record<string, string>,
@@ -98,6 +101,7 @@ type RuntimeContext = {
   draft: boolean;
   runId: string;
   branchName: string;
+  runtimeImage: RuntimeImageBuildResult & { source: "configured" | "built" };
 };
 
 type PhaseBody = () => Promise<string | undefined>;
@@ -112,6 +116,7 @@ export async function runCodexCage(
   const context = await prepareRuntimeContext(cwd, options, dependencies);
   const openStore = dependencies.openRunStore ?? openRunStore;
   const createSandbox = dependencies.createDockerSandbox ?? createDockerSandbox;
+  const buildImage = dependencies.buildRuntimeImage ?? buildRuntimeImage;
   const makeShellRunner = dependencies.createShellRunner ?? createDockerShellRunner;
   const makeComposeProject = dependencies.createComposeProject ?? createComposeProject;
   const review = dependencies.runIndependentReview ?? runIndependentReview;
@@ -136,6 +141,7 @@ export async function runCodexCage(
       config: context.config,
       warnings: context.configWarnings,
       repoSource: context.repoResolution.source,
+      runtimeImage: context.runtimeImage,
     });
 
     await runPhase(store, context.runId, "preflight", async () => {
@@ -146,6 +152,43 @@ export async function runCodexCage(
         `Branch: ${context.branchName}`,
       ].join("\n");
     });
+
+    const runtimeDockerfile = context.config.runtime.dockerfile;
+
+    if (runtimeDockerfile !== null) {
+      try {
+        context.runtimeImage = await runPhase(
+          store,
+          context.runId,
+          "runtime_image",
+          async () => {
+            const result = await buildImage({
+              runId: context.runId,
+              dockerfilePath: resolve(cwd, runtimeDockerfile),
+              contextPath: resolve(cwd, ".codex-cage"),
+            });
+
+            return {
+              log: [
+                `Built runtime image: ${result.image}`,
+                `Dockerfile: ${result.dockerfilePath}`,
+                `Build context: ${result.contextPath}`,
+              ].join("\n"),
+              value: { ...result, source: "built" as const },
+            };
+          },
+        );
+      } catch (error) {
+        throw new RunFailureError("runtime_image_failed", formatError(error));
+      }
+    }
+
+    await writeJsonArtifact(
+      store,
+      context.runId,
+      "runtime-image.json",
+      context.runtimeImage,
+    );
 
     if (hasComposeServices(context.config.services)) {
       const composeFile = context.config.services.compose;
@@ -174,6 +217,7 @@ export async function runCodexCage(
     const sandboxOptions: DockerSandboxOptions = {
       runId: context.runId,
       cloneUrl: context.authenticatedRepo.cloneUrl,
+      image: context.runtimeImage.image,
       env: context.secrets,
     };
 
@@ -256,7 +300,7 @@ async function prepareRuntimeContext(
   const resolveRepo = dependencies.resolveTargetRepo ?? resolveTargetRepo;
   const authenticateRepo =
     dependencies.createAuthenticatedRepo ?? createAuthenticatedRepo;
-  const secrets = await readEnv(cwd);
+  const secrets = normalizeRuntimeEnv(await readEnv(cwd));
   const issueOptions: Parameters<typeof fetchIssueContext>[1] = {
     comments: configResult.config.issue.comments,
   };
@@ -286,6 +330,12 @@ async function prepareRuntimeContext(
   const draft = options.draft ?? configResult.config.pr.draft;
   const runId = dependencies.generateRunId?.() ?? generateRunId();
   const branchName = generateBranchName({ issue, runId });
+  const runtimeImage = {
+    image: configResult.config.runtime.image,
+    dockerfilePath: "",
+    contextPath: "",
+    source: "configured" as const,
+  };
 
   return {
     cwd,
@@ -300,6 +350,7 @@ async function prepareRuntimeContext(
     draft,
     runId,
     branchName,
+    runtimeImage,
   };
 }
 
@@ -327,6 +378,17 @@ async function readConfig(cwd: string): Promise<{
       error instanceof Error ? error.message : "Invalid Codex Cage config.",
     );
   }
+}
+
+function normalizeRuntimeEnv(env: Record<string, string>): Record<string, string> {
+  if (env.GITHUB_TOKEN === undefined || env.GH_TOKEN !== undefined) {
+    return env;
+  }
+
+  return {
+    ...env,
+    GH_TOKEN: env.GITHUB_TOKEN,
+  };
 }
 
 async function runImplementationLoop(input: {

--- a/src/state.ts
+++ b/src/state.ts
@@ -31,6 +31,7 @@ export const failureCodes = [
   "missing_config",
   "invalid_config",
   "setup_failed",
+  "runtime_image_failed",
   "verify_failed",
   "review_blocking",
   "secret_guard_failed",
@@ -45,6 +46,7 @@ export type FailureCode = (typeof failureCodes)[number];
 
 export const phaseNames = [
   "preflight",
+  "runtime_image",
   "cloning",
   "setup",
   "implement",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { codexCageConfigSchema, parseCodexCageConfig } from "../src/config.js";
+import { defaultSandboxImage } from "../src/docker.js";
 
 test("config schema accepts a minimal valid config", () => {
   const config = codexCageConfigSchema.parse({
@@ -12,6 +13,10 @@ test("config schema accepts a minimal valid config", () => {
   assert.equal(config.git.base, "main");
   assert.equal(config.pr.draft, false);
   assert.equal(config.issue.comments, 10);
+  assert.deepEqual(config.runtime, {
+    image: defaultSandboxImage,
+    dockerfile: null,
+  });
 });
 
 test("config schema rejects empty verify commands", () => {
@@ -22,6 +27,21 @@ test("config schema rejects empty verify commands", () => {
       }),
     /Array must contain at least 1 element/,
   );
+});
+
+test("config schema accepts explicit runtime image and Dockerfile", () => {
+  const config = codexCageConfigSchema.parse({
+    verify: ["npm test"],
+    runtime: {
+      image: "registry.example.com/codex-cage/base:custom",
+      dockerfile: ".codex-cage/Dockerfile",
+    },
+  });
+
+  assert.deepEqual(config.runtime, {
+    image: "registry.example.com/codex-cage/base:custom",
+    dockerfile: ".codex-cage/Dockerfile",
+  });
 });
 
 test("config schema preserves unknown keys for forward compatibility", () => {

--- a/test/docker.test.ts
+++ b/test/docker.test.ts
@@ -1,11 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildRuntimeImage,
   cleanupManagedDockerResources,
   createDockerSandbox,
+  defaultSandboxImage,
+  dockerBuildArgs,
   dockerResourceNames,
   dockerRunArgs,
   networkCreateArgs,
+  runtimeImageName,
   volumeCreateArgs,
   type DockerCommandResult,
   type DockerCommandRunner,
@@ -55,6 +59,7 @@ test("dockerResourceNames creates stable Docker-safe resource names", () => {
     volumeName: "codex-cage-run-123-abc-workspace",
     networkName: "codex-cage-run-123-abc",
   });
+  assert.equal(runtimeImageName("RUN 123/ABC"), "codex-cage/runtime-run-123-abc:latest");
 });
 
 test("volume and network resources carry managed labels", () => {
@@ -80,7 +85,7 @@ test("volume and network resources carry managed labels", () => {
 
 test("dockerRunArgs uses volume workspace and avoids host-sensitive mounts", () => {
   const args = dockerRunArgs({
-    image: "codex-cage/base:0.1.0",
+    image: defaultSandboxImage,
     networkName: "codex-cage-run-1",
     volumeName: "codex-cage-run-1-workspace",
     workspacePath: "/workspace",
@@ -106,6 +111,57 @@ test("dockerRunArgs uses volume workspace and avoids host-sensitive mounts", () 
   );
   assert.equal(joinedArgs.includes("secret"), false);
   assert.deepEqual(args.slice(-3), ["sh", "-lc", "npm test"]);
+});
+
+test("dockerBuildArgs labels per-run runtime images", () => {
+  assert.deepEqual(
+    dockerBuildArgs({
+      image: "codex-cage/runtime-run-1:latest",
+      dockerfilePath: "/repo/.codex-cage/Dockerfile",
+      contextPath: "/repo/.codex-cage",
+      labels: {
+        "codex-cage.run_id": "run-1",
+        "codex-cage.kind": "runtime-image",
+      },
+    }),
+    [
+      "build",
+      "--file",
+      "/repo/.codex-cage/Dockerfile",
+      "--tag",
+      "codex-cage/runtime-run-1:latest",
+      "--label",
+      "codex-cage.managed=true",
+      "--label",
+      "codex-cage.run_id=run-1",
+      "--label",
+      "codex-cage.kind=runtime-image",
+      "/repo/.codex-cage",
+    ],
+  );
+});
+
+test("buildRuntimeImage builds a labeled per-run image", async () => {
+  const runner = recordingRunner();
+  const result = await buildRuntimeImage({
+    runId: "run-1",
+    dockerfilePath: "/repo/.codex-cage/Dockerfile",
+    contextPath: "/repo/.codex-cage",
+    runner,
+  });
+
+  assert.deepEqual(result, {
+    image: "codex-cage/runtime-run-1:latest",
+    dockerfilePath: "/repo/.codex-cage/Dockerfile",
+    contextPath: "/repo/.codex-cage",
+  });
+  assert.deepEqual(runner.calls[0]?.args.slice(0, 5), [
+    "build",
+    "--file",
+    "/repo/.codex-cage/Dockerfile",
+    "--tag",
+    "codex-cage/runtime-run-1:latest",
+  ]);
 });
 
 test("createDockerSandbox creates resources, clones into volume, runs commands, and cleans up", async () => {
@@ -198,6 +254,7 @@ test("cleanupManagedDockerResources removes stopped resources and skips active r
 
   assert.deepEqual(report, {
     containers: ["stopped1"],
+    images: [],
     networks: ["codex-cage-run-stale"],
     volumes: ["codex-cage-run-stale-workspace"],
     skippedActiveRunIds: ["run-active"],
@@ -240,6 +297,8 @@ test("cleanupManagedDockerResources --all removes active managed resources expli
     result(
       "codex-cage-run-active-workspace\trun-active\ncodex-cage-run-stale-workspace\trun-stale\n",
     ),
+    result("image1\tcodex-cage/runtime-run-stale:latest\trun-stale\n"),
+    result(),
     result(),
     result(),
     result(),
@@ -249,23 +308,33 @@ test("cleanupManagedDockerResources --all removes active managed resources expli
 
   assert.deepEqual(report, {
     containers: ["active1", "stopped1"],
+    images: ["codex-cage/runtime-run-stale:latest"],
     networks: ["codex-cage-run-active", "codex-cage-run-stale"],
     volumes: ["codex-cage-run-active-workspace", "codex-cage-run-stale-workspace"],
     skippedActiveRunIds: [],
   });
-  assert.deepEqual(runner.calls.at(3), ["rm", "--force", "active1", "stopped1"]);
-  assert.deepEqual(runner.calls.at(4), [
+  assert.deepEqual(runner.calls.at(3), [
+    "image",
+    "ls",
+    "--filter",
+    "label=codex-cage.managed=true",
+    "--format",
+    '{{.ID}}\t{{.Repository}}:{{.Tag}}\t{{.Label "codex-cage.run_id"}}',
+  ]);
+  assert.deepEqual(runner.calls.at(4), ["rm", "--force", "active1", "stopped1"]);
+  assert.deepEqual(runner.calls.at(5), [
     "network",
     "rm",
     "codex-cage-run-active",
     "codex-cage-run-stale",
   ]);
-  assert.deepEqual(runner.calls.at(5), [
+  assert.deepEqual(runner.calls.at(6), [
     "volume",
     "rm",
     "codex-cage-run-active-workspace",
     "codex-cage-run-stale-workspace",
   ]);
+  assert.deepEqual(runner.calls.at(7), ["image", "rm", "image1"]);
 });
 
 test("cleanupManagedDockerResources reports no-op cleanup without touching artifacts", async () => {
@@ -275,6 +344,7 @@ test("cleanupManagedDockerResources reports no-op cleanup without touching artif
 
   assert.deepEqual(report, {
     containers: [],
+    images: [],
     networks: [],
     volumes: [],
     skippedActiveRunIds: [],

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -21,6 +21,8 @@ test("init creates config, env example, and gitignore entries", async () => {
     const config = await readFile(join(cwd, ".codex-cage.yml"), "utf8");
     assert.match(config, /verify:/);
     assert.match(config, /Replace this with your real test command/);
+    assert.match(config, /runtime:/);
+    assert.match(config, /ghcr\.io\/jhowliu\/codex-cage\/base:0\.1\.0/);
 
     const envExample = await readFile(join(cwd, ".codex-cage.env.example"), "utf8");
     assert.match(envExample, /OPENAI_API_KEY=/);
@@ -54,7 +56,7 @@ test("init can create optional Dockerfile", async () => {
 
     assert.ok(result.created.includes(".codex-cage/Dockerfile"));
     const dockerfile = await readFile(join(cwd, ".codex-cage", "Dockerfile"), "utf8");
-    assert.match(dockerfile, /FROM node:22-bookworm/);
+    assert.match(dockerfile, /FROM ghcr\.io\/jhowliu\/codex-cage\/base:0\.1\.0/);
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,9 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import type { DockerSandbox, DockerSandboxOptions } from "../src/docker.js";
+import {
+  defaultSandboxImage,
+  type DockerSandbox,
+  type DockerSandboxOptions,
+} from "../src/docker.js";
 import type { IssueContext } from "../src/issue.js";
 import type { CommandResult, PublishSuccessfulRunInput } from "../src/publish.js";
 import type { GithubRepo, RepoResolution } from "../src/repo.js";
@@ -105,6 +109,7 @@ verify:
   - npm test
 `);
   const events: string[] = [];
+  const sandboxOptions: DockerSandboxOptions[] = [];
   const shell = shellRunner(
     new Map([
       ["git fetch origin", commandResult()],
@@ -140,7 +145,10 @@ verify:
           redactedCloneUrl:
             "https://x-access-token:[REDACTED]@github.com/jhowliu/codex-cage.git",
         }),
-        createDockerSandbox: (_options: DockerSandboxOptions) => fakeSandbox(events),
+        createDockerSandbox: (options: DockerSandboxOptions) => {
+          sandboxOptions.push(options);
+          return fakeSandbox(events);
+        },
         createShellRunner: () => shell,
         runIndependentReview: async () => passingReview(),
         publishSuccessfulRun: async (input) => {
@@ -163,6 +171,11 @@ verify:
       prUrl: "https://github.com/jhowliu/codex-cage/pull/26",
     });
     assert.deepEqual(events, ["sandbox:create", "sandbox:clone", "sandbox:cleanup"]);
+    assert.equal(sandboxOptions[0]?.image, defaultSandboxImage);
+    assert.deepEqual(sandboxOptions[0]?.env, {
+      GH_TOKEN: "token-value",
+      GITHUB_TOKEN: "token-value",
+    });
     assert.equal(published.length, 1);
     assert.equal(published[0]?.metadata.verification[0], "`npm test` passed");
 
@@ -176,6 +189,159 @@ verify:
       details.phases.map((phase) => phase.name),
       ["preflight", "cloning", "implement", "verify", "review", "pr"],
     );
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("runCodexCage builds configured runtime Dockerfiles before cloning", async () => {
+  const cwd = await createProject(`
+verify:
+  - npm test
+runtime:
+  image: registry.example.com/base:custom
+  dockerfile: .codex-cage/Dockerfile
+`);
+  const events: string[] = [];
+  const sandboxOptions: DockerSandboxOptions[] = [];
+  const shell = shellRunner(
+    new Map([
+      ["git fetch origin", commandResult()],
+      ["codex exec", commandResult("implemented")],
+      ["npm test", commandResult("tests passed")],
+      [
+        "git add --intent-to-add",
+        commandResult(`diff --git a/src/app.ts b/src/app.ts
+@@ -1 +1,2 @@
+ export const ok = true;
++export const changed = true;
+`),
+      ],
+    ]),
+  );
+
+  try {
+    const result = await runCodexCage(
+      {
+        cwd,
+        issueUrl: issue.url,
+      },
+      {
+        generateRunId: () => "run-image-123",
+        readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
+        fetchIssueContext: async () => issue,
+        resolveTargetRepo: async () => repoResolution,
+        createAuthenticatedRepo: () => ({
+          repo,
+          cloneUrl:
+            "https://x-access-token:token-value@github.com/jhowliu/codex-cage.git",
+          redactedCloneUrl:
+            "https://x-access-token:[REDACTED]@github.com/jhowliu/codex-cage.git",
+        }),
+        buildRuntimeImage: async (options) => {
+          events.push(`build:${options.dockerfilePath}:${options.contextPath}`);
+          return {
+            image: "codex-cage/runtime-run-image-123:latest",
+            dockerfilePath: options.dockerfilePath,
+            contextPath: options.contextPath,
+          };
+        },
+        createDockerSandbox: (options) => {
+          sandboxOptions.push(options);
+          return fakeSandbox(events);
+        },
+        createShellRunner: () => shell,
+        runIndependentReview: async () => passingReview(),
+        publishSuccessfulRun: async (input) => ({
+          branchName: input.branchName ?? "codex-cage/gh-26-run-test",
+          commitMessage: "#26 Wire run command",
+          prTitle: "#26 Wire run command",
+          prBody: "body",
+          prUrl: "https://github.com/jhowliu/codex-cage/pull/26",
+        }),
+      },
+    );
+
+    assert.equal(result.status, "succeeded");
+    assert.match(events[0] ?? "", /build:/);
+    assert.deepEqual(events.slice(1), [
+      "sandbox:create",
+      "sandbox:clone",
+      "sandbox:cleanup",
+    ]);
+    assert.equal(sandboxOptions[0]?.image, "codex-cage/runtime-run-image-123:latest");
+
+    const store = await openRunStore(cwd);
+    const details = store.getRunDetails("run-image-123");
+    const runtimeImage = await readFile(
+      join(cwd, ".codex-cage", "runs", "run-image-123", "runtime-image.json"),
+      "utf8",
+    );
+    store.close();
+
+    assert.deepEqual(
+      details.phases.map((phase) => phase.name),
+      ["preflight", "runtime_image", "cloning", "implement", "verify", "review", "pr"],
+    );
+    assert.match(runtimeImage, /codex-cage\/runtime-run-image-123:latest/);
+    assert.match(runtimeImage, /"source": "built"/);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("runCodexCage records runtime image build failures", async () => {
+  const cwd = await createProject(`
+verify:
+  - npm test
+runtime:
+  dockerfile: .codex-cage/Dockerfile
+`);
+  const events: string[] = [];
+
+  try {
+    const result = await runCodexCage(
+      {
+        cwd,
+        issueUrl: issue.url,
+      },
+      {
+        generateRunId: () => "run-image-failed",
+        readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
+        fetchIssueContext: async () => issue,
+        resolveTargetRepo: async () => repoResolution,
+        createAuthenticatedRepo: () => ({
+          repo,
+          cloneUrl:
+            "https://x-access-token:token-value@github.com/jhowliu/codex-cage.git",
+          redactedCloneUrl:
+            "https://x-access-token:[REDACTED]@github.com/jhowliu/codex-cage.git",
+        }),
+        buildRuntimeImage: async () => {
+          events.push("build");
+          throw new Error("docker build failed");
+        },
+        createDockerSandbox: () => {
+          throw new Error("sandbox should not be created after image build failure");
+        },
+      },
+    );
+
+    assert.deepEqual(result, {
+      runId: "run-image-failed",
+      status: "failed",
+      failureCode: "runtime_image_failed",
+      prUrl: null,
+    });
+    assert.deepEqual(events, ["build"]);
+
+    const store = await openRunStore(cwd);
+    const details = store.getRunDetails("run-image-failed");
+    store.close();
+
+    assert.equal(details.run.failureCode, "runtime_image_failed");
+    assert.equal(details.phases.at(-1)?.name, "runtime_image");
+    assert.equal(details.phases.at(-1)?.status, "failed");
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- add `runtime.image` and `runtime.dockerfile` config with the GHCR base image default
- build labeled per-run runtime images from `.codex-cage/Dockerfile` before cloning, using `.codex-cage/` as build context
- derive `GH_TOKEN` from `GITHUB_TOKEN`, record runtime image artifacts, and allow `cleanup --all` to remove managed runtime images
- update init/docs/tests for the new runtime behavior

## Validation

- `npm run typecheck`
- `npm test`
- `npm run qa`
- `npm run format`
- `npm --cache /tmp/codex-cage-npm-cache pack --dry-run`
- `git diff --check`

Stacked on #32.

Closes #31