### PR TITLE
Add prompt instruction artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ codex-cage init
 This creates:
 
 - `.codex-cage.yml`
+- `.codex-cage/instructions.md`
 - `.codex-cage.env.example`
 - `.gitignore` entries for local Codex Cage runtime state
 
@@ -43,6 +44,8 @@ codex-cage init --dockerfile
 ```
 
 The generated verify command intentionally fails until replaced with the target repo's real test command.
+
+Codex Cage includes root-level repository instruction files in implementation and review prompts when they exist: `AGENTS.md`, `.codex-cage/instructions.md`, `.github/copilot-instructions.md`, and `CLAUDE.md`. The injected instruction text is capped and saved as run artifacts with the rendered prompts.
 
 ## Inspect Local Runs
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -60,6 +60,7 @@ codex-cage init
 This creates:
 
 - `.codex-cage.yml`
+- `.codex-cage/instructions.md`
 - `.codex-cage.env.example`
 - `.gitignore` entries for `.codex-cage.env`, run artifacts, and SQLite metadata
 
@@ -115,6 +116,24 @@ guards:
 `verify` must contain at least one command. The generated default intentionally fails until replaced with the target repo's real validation command.
 
 `runtime.image` accepts any valid Docker image reference and defaults to the Codex Cage GHCR base image. If `runtime.dockerfile` is set, Codex Cage builds a labeled per-run image before cloning the target repository. The first version uses `.codex-cage/` as the Docker build context, so target runtime Dockerfiles should keep package-install inputs inside that directory.
+
+## Prompt Instructions
+
+Codex Cage injects root-level repository instruction files into implementation and review prompts when they exist:
+
+- `AGENTS.md`
+- `.codex-cage/instructions.md`
+- `.github/copilot-instructions.md`
+- `CLAUDE.md`
+
+Instruction injection is capped at 32 KB total. Missing files are omitted from prompts but recorded in `prompt-context.json`. Codex Cage does not inject README excerpts or raw `.codex-cage.yml` content.
+
+Each run records prompt context artifacts under `.codex-cage/runs/<run-id>`:
+
+- `prompt-context.json`
+- `instructions.md` when any instructions were included
+- `implementation-prompt-<iteration>.md`
+- `review-prompt-<cycle>.md`
 
 ## Running GitHub Issues
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -14,6 +14,7 @@ const configPath = ".codex-cage.yml";
 const envExamplePath = ".codex-cage.env.example";
 const gitignorePath = ".gitignore";
 const dockerfilePath = ".codex-cage/Dockerfile";
+const instructionsPath = ".codex-cage/instructions.md";
 
 const defaultConfig = `# Codex Cage target repo configuration.
 # Replace the verify command before running Codex Cage.
@@ -67,6 +68,13 @@ const dockerfile = `FROM ghcr.io/jhowliu/codex-cage/base:0.1.0
 # Add target-repo system dependencies here.
 `;
 
+const instructions = `# Codex Cage Instructions
+
+- Follow the repository's existing style and tests.
+- Keep changes focused on the issue.
+- Do not commit, push, create pull requests, or write secrets.
+`;
+
 const gitignoreEntries = [".codex-cage.env", ".codex-cage/runs/", ".codex-cage/*.sqlite"];
 
 export async function initProject(
@@ -77,6 +85,7 @@ export async function initProject(
   const updated: string[] = [];
   const configFilePath = join(cwd, configPath);
   const dockerfileFilePath = join(cwd, dockerfilePath);
+  const instructionsFilePath = join(cwd, instructionsPath);
 
   await assertFileDoesNotExist(cwd, configFilePath);
 
@@ -85,6 +94,9 @@ export async function initProject(
   }
 
   await createFileOnce(cwd, configFilePath, defaultConfig, created);
+  if (!(await fileExists(instructionsFilePath))) {
+    await createFileOnce(cwd, instructionsFilePath, instructions, created);
+  }
   await mergeEnvExample(cwd, join(cwd, envExamplePath), created, updated);
   await appendGitignoreEntries(cwd, join(cwd, gitignorePath), updated);
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -32,7 +32,7 @@ runtime:
   dockerfile: null
 
 agent:
-  model: gpt-5.4
+  model: gpt-5.5
   max_iterations: 5
   max_review_cycles: 2
 

--- a/src/prompt-context.ts
+++ b/src/prompt-context.ts
@@ -1,0 +1,139 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+export const instructionFileCandidates = [
+  "AGENTS.md",
+  ".codex-cage/instructions.md",
+  ".github/copilot-instructions.md",
+  "CLAUDE.md",
+] as const;
+
+export const instructionPromptLimitBytes = 32 * 1024;
+
+export type InstructionFileStatus = "included" | "missing" | "truncated" | "skipped";
+
+export type InstructionFileResult = {
+  path: string;
+  status: InstructionFileStatus;
+  bytes: number;
+  includedBytes: number;
+};
+
+export type PromptContext = {
+  instructions: string;
+  instructionFiles: InstructionFileResult[];
+  limitBytes: number;
+  truncated: boolean;
+};
+
+export async function buildPromptContext(cwd: string): Promise<PromptContext> {
+  const instructionFiles: InstructionFileResult[] = [];
+  const sections: string[] = [];
+  let remainingBytes = instructionPromptLimitBytes;
+  let truncated = false;
+
+  for (const path of instructionFileCandidates) {
+    const content = await readOptionalInstruction(cwd, path);
+
+    if (content === null) {
+      instructionFiles.push({
+        path,
+        status: "missing",
+        bytes: 0,
+        includedBytes: 0,
+      });
+      continue;
+    }
+
+    const contentBytes = Buffer.byteLength(content, "utf8");
+
+    if (remainingBytes <= 0) {
+      truncated = true;
+      instructionFiles.push({
+        path,
+        status: "skipped",
+        bytes: contentBytes,
+        includedBytes: 0,
+      });
+      continue;
+    }
+
+    const sectionPrefix = `## ${path}\n\n`;
+    const sectionOverheadBytes = Buffer.byteLength(sectionPrefix, "utf8");
+    const contentLimit = Math.max(0, remainingBytes - sectionOverheadBytes);
+    const limited = truncateUtf8(
+      content,
+      contentLimit,
+      `\n\n[Instruction file truncated at ${contentLimit} bytes]\n`,
+    );
+    const section = `${sectionPrefix}${limited.content.trimEnd()}`;
+    const sectionBytes = Buffer.byteLength(section, "utf8");
+
+    remainingBytes = Math.max(0, remainingBytes - sectionBytes);
+    truncated = truncated || limited.truncated;
+    instructionFiles.push({
+      path,
+      status: limited.truncated ? "truncated" : "included",
+      bytes: contentBytes,
+      includedBytes: Buffer.byteLength(limited.content, "utf8"),
+    });
+    sections.push(section);
+  }
+
+  return {
+    instructions: sections.join("\n\n"),
+    instructionFiles,
+    limitBytes: instructionPromptLimitBytes,
+    truncated,
+  };
+}
+
+export function formatInstructionsForPrompt(context: PromptContext): string {
+  if (context.instructions === "") {
+    return "";
+  }
+
+  return `Repository instructions:
+Follow these repository-specific instructions when they apply. If source files or tests conflict with this context, treat the source files and tests as authoritative.
+
+${context.instructions}`;
+}
+
+async function readOptionalInstruction(
+  cwd: string,
+  path: string,
+): Promise<string | null> {
+  try {
+    return await readFile(resolve(cwd, path), "utf8");
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function truncateUtf8(
+  value: string,
+  limitBytes: number,
+  marker: string,
+): { content: string; truncated: boolean } {
+  if (Buffer.byteLength(value, "utf8") <= limitBytes) {
+    return { content: value, truncated: false };
+  }
+
+  let content = value;
+  const markerBytes = Buffer.byteLength(marker, "utf8");
+  const contentLimit = Math.max(0, limitBytes - markerBytes);
+
+  while (Buffer.byteLength(content, "utf8") > contentLimit) {
+    content = content.slice(0, -1);
+  }
+
+  return { content: `${content}${marker}`, truncated: true };
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -32,12 +32,18 @@ import {
   type CommandRunner,
 } from "./publish.js";
 import {
+  buildPromptContext,
+  formatInstructionsForPrompt,
+  type PromptContext,
+} from "./prompt-context.js";
+import {
   createAuthenticatedRepo,
   resolveTargetRepo,
   type AuthenticatedRepo,
   type RepoResolution,
 } from "./repo.js";
 import {
+  buildReviewPrompt,
   runIndependentReview,
   type ReviewAgentRunner,
   ReviewModifiedDiffError,
@@ -102,6 +108,7 @@ type RuntimeContext = {
   runId: string;
   branchName: string;
   runtimeImage: RuntimeImageBuildResult & { source: "configured" | "built" };
+  promptContext: PromptContext;
 };
 
 type PhaseBody = () => Promise<string | undefined>;
@@ -137,6 +144,7 @@ export async function runCodexCage(
       branch: context.branchName,
     });
     await writeJsonArtifact(store, context.runId, "issue.json", context.issue);
+    await writePromptContextArtifacts(store, context);
     await writeJsonArtifact(store, context.runId, "resolved-config.json", {
       config: context.config,
       warnings: context.configWarnings,
@@ -336,6 +344,7 @@ async function prepareRuntimeContext(
     contextPath: "",
     source: "configured" as const,
   };
+  const promptContext = await buildPromptContext(cwd);
 
   return {
     cwd,
@@ -351,6 +360,7 @@ async function prepareRuntimeContext(
     runId,
     branchName,
     runtimeImage,
+    promptContext,
   };
 }
 
@@ -411,15 +421,22 @@ async function runImplementationLoop(input: {
   ) {
     await input.store.updateRunStatus(input.context.runId, { status: "implementing" });
     await runPhase(input.store, input.context.runId, "implement", async () => {
+      const prompt = buildImplementationPrompt({
+        context: input.context,
+        iteration,
+        feedback,
+      });
+      await input.store.writeArtifact(
+        input.context.runId,
+        `implementation-prompt-${iteration}.md`,
+        input.redactor(prompt),
+      );
+
       return await requiredShell(
         input.shell,
         codexExecCommand({
           model: input.context.model,
-          prompt: buildImplementationPrompt({
-            context: input.context,
-            iteration,
-            feedback,
-          }),
+          prompt,
         }),
         input.redactor,
       );
@@ -473,19 +490,32 @@ async function runImplementationLoop(input: {
       input.context.runId,
       "review",
       async () => {
+        const reviewIssueContext = formatReviewIssueContext(input.context);
+        const resultMetadata = {
+          runId: input.context.runId,
+          iteration,
+          repo: input.context.repoResolution.repo.fullName,
+        };
+        const reviewPrompt = buildReviewPrompt({
+          issueContext: reviewIssueContext,
+          verificationSummary: verification.summary,
+          resultMetadata,
+          diff,
+        });
+        await input.store.writeArtifact(
+          input.context.runId,
+          `review-prompt-${reviewCycle}.md`,
+          input.redactor(reviewPrompt),
+        );
         const result = await input.review({
           cwd: input.context.cwd,
           model: input.context.model,
           cycle: reviewCycle,
           maxReviewCycles: input.context.config.agent.max_review_cycles,
-          issueContext: formatIssueContext(input.context.issue),
+          issueContext: reviewIssueContext,
           diff,
           verificationSummary: verification.summary,
-          resultMetadata: {
-            runId: input.context.runId,
-            iteration,
-            repo: input.context.repoResolution.repo.fullName,
-          },
+          resultMetadata,
           readCurrentDiff: async () => await readCurrentDiff(input.shell),
           runner: reviewAgentRunner(input.shell),
           env: input.context.secrets,
@@ -769,12 +799,21 @@ Iteration: ${input.iteration}
 Repository: ${input.context.repoResolution.repo.fullName}
 Base branch: ${input.context.baseBranch}
 
+${formatInstructionsForPrompt(input.context.promptContext)}
+
 Issue:
 ${formatIssueContext(input.context.issue)}
 
 Feedback to address:
 ${feedback}
 `;
+}
+
+function formatReviewIssueContext(context: RuntimeContext): string {
+  return `${formatInstructionsForPrompt(context.promptContext)}
+
+Issue:
+${formatIssueContext(context.issue)}`;
 }
 
 function formatIssueContext(issue: IssueContext): string {
@@ -875,6 +914,25 @@ async function writeJsonArtifact(
   value: unknown,
 ): Promise<void> {
   await store.writeArtifact(runId, name, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function writePromptContextArtifacts(
+  store: RunStore,
+  context: RuntimeContext,
+): Promise<void> {
+  await writeJsonArtifact(store, context.runId, "prompt-context.json", {
+    instructionFiles: context.promptContext.instructionFiles,
+    limitBytes: context.promptContext.limitBytes,
+    truncated: context.promptContext.truncated,
+  });
+
+  if (context.promptContext.instructions !== "") {
+    await store.writeArtifact(
+      context.runId,
+      "instructions.md",
+      context.promptContext.instructions,
+    );
+  }
 }
 
 async function writeFailureSummary(

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -15,7 +15,11 @@ test("init creates config, env example, and gitignore entries", async () => {
   try {
     const result = await initProject(cwd);
 
-    assert.deepEqual(result.created, [".codex-cage.yml", ".codex-cage.env.example"]);
+    assert.deepEqual(result.created, [
+      ".codex-cage.yml",
+      ".codex-cage/instructions.md",
+      ".codex-cage.env.example",
+    ]);
     assert.deepEqual(result.updated, [".gitignore"]);
 
     const config = await readFile(join(cwd, ".codex-cage.yml"), "utf8");
@@ -28,9 +32,39 @@ test("init creates config, env example, and gitignore entries", async () => {
     assert.match(envExample, /OPENAI_API_KEY=/);
     assert.match(envExample, /GITHUB_TOKEN=/);
 
+    const instructions = await readFile(
+      join(cwd, ".codex-cage", "instructions.md"),
+      "utf8",
+    );
+    assert.match(instructions, /Do not commit, push, create pull requests/);
+
     const gitignore = await readFile(join(cwd, ".gitignore"), "utf8");
     assert.match(gitignore, /\.codex-cage\.env/);
     assert.match(gitignore, /\.codex-cage\/runs\//);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("init leaves existing instructions untouched", async () => {
+  const cwd = await tempRepo();
+
+  try {
+    await mkdir(join(cwd, ".codex-cage"), { recursive: true });
+    await writeFile(
+      join(cwd, ".codex-cage", "instructions.md"),
+      "custom instructions\n",
+      "utf8",
+    );
+
+    const result = await initProject(cwd);
+    const instructions = await readFile(
+      join(cwd, ".codex-cage", "instructions.md"),
+      "utf8",
+    );
+
+    assert.equal(result.created.includes(".codex-cage/instructions.md"), false);
+    assert.equal(instructions, "custom instructions\n");
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }

--- a/test/prompt-context.test.ts
+++ b/test/prompt-context.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  buildPromptContext,
+  formatInstructionsForPrompt,
+  instructionPromptLimitBytes,
+} from "../src/prompt-context.js";
+
+async function tempProject(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "codex-cage-prompt-context-"));
+}
+
+test("buildPromptContext reads root instruction files in priority order", async () => {
+  const cwd = await tempProject();
+
+  try {
+    await mkdir(join(cwd, ".codex-cage"), { recursive: true });
+    await mkdir(join(cwd, ".github"), { recursive: true });
+    await writeFile(join(cwd, "AGENTS.md"), "Agent rules\n", "utf8");
+    await writeFile(join(cwd, ".codex-cage", "instructions.md"), "Cage rules\n", "utf8");
+    await writeFile(
+      join(cwd, ".github", "copilot-instructions.md"),
+      "Copilot rules\n",
+      "utf8",
+    );
+    await writeFile(join(cwd, "CLAUDE.md"), "Claude rules\n", "utf8");
+
+    const context = await buildPromptContext(cwd);
+
+    assert.deepEqual(
+      context.instructionFiles.map((file) => [file.path, file.status]),
+      [
+        ["AGENTS.md", "included"],
+        [".codex-cage/instructions.md", "included"],
+        [".github/copilot-instructions.md", "included"],
+        ["CLAUDE.md", "included"],
+      ],
+    );
+    assert.equal(
+      context.instructions.indexOf("## AGENTS.md") <
+        context.instructions.indexOf("## .codex-cage/instructions.md"),
+      true,
+    );
+    assert.match(formatInstructionsForPrompt(context), /Repository instructions:/);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("buildPromptContext records missing files and truncates large instructions", async () => {
+  const cwd = await tempProject();
+
+  try {
+    await writeFile(join(cwd, "AGENTS.md"), "a".repeat(40000), "utf8");
+
+    const context = await buildPromptContext(cwd);
+
+    assert.equal(context.limitBytes, instructionPromptLimitBytes);
+    assert.equal(context.truncated, true);
+    assert.equal(context.instructionFiles[0]?.status, "truncated");
+    assert.equal(context.instructionFiles[1]?.status, "missing");
+    assert.match(context.instructions, /Instruction file truncated/);
+    assert.equal(Buffer.byteLength(context.instructions, "utf8") <= 32768, true);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -108,6 +108,7 @@ test("runCodexCage executes the happy path and records a successful run", async 
 verify:
   - npm test
 `);
+  await writeFile(join(cwd, "AGENTS.md"), "Always write focused tests.\n", "utf8");
   const events: string[] = [];
   const sandboxOptions: DockerSandboxOptions[] = [];
   const shell = shellRunner(
@@ -126,6 +127,7 @@ verify:
     ]),
   );
   const published: PublishSuccessfulRunInput[] = [];
+  let reviewIssueContext = "";
 
   try {
     const result = await runCodexCage(
@@ -150,7 +152,10 @@ verify:
           return fakeSandbox(events);
         },
         createShellRunner: () => shell,
-        runIndependentReview: async () => passingReview(),
+        runIndependentReview: async (input) => {
+          reviewIssueContext = input.issueContext;
+          return passingReview();
+        },
         publishSuccessfulRun: async (input) => {
           published.push(input);
           return {
@@ -182,9 +187,26 @@ verify:
     const store = await openRunStore(cwd);
     const details = store.getRunDetails("run-test-123");
     store.close();
+    const runDirectory = join(cwd, ".codex-cage", "runs", "run-test-123");
+    const implementationPrompt = await readFile(
+      join(runDirectory, "implementation-prompt-1.md"),
+      "utf8",
+    );
+    const reviewPrompt = await readFile(join(runDirectory, "review-prompt-0.md"), "utf8");
+    const promptContext = await readFile(
+      join(runDirectory, "prompt-context.json"),
+      "utf8",
+    );
+    const instructions = await readFile(join(runDirectory, "instructions.md"), "utf8");
 
     assert.equal(details.run.status, "succeeded");
     assert.equal(details.run.prUrl, "https://github.com/jhowliu/codex-cage/pull/26");
+    assert.match(implementationPrompt, /Repository instructions:/);
+    assert.match(implementationPrompt, /Always write focused tests/);
+    assert.match(reviewIssueContext, /Repository instructions:/);
+    assert.match(reviewPrompt, /Verification summary:/);
+    assert.match(promptContext, /AGENTS\.md/);
+    assert.match(instructions, /Always write focused tests/);
     assert.deepEqual(
       details.phases.map((phase) => phase.name),
       ["preflight", "cloning", "implement", "verify", "review", "pr"],


### PR DESCRIPTION
Closes #30

## Summary

- Inject bounded repository instruction files into implementation and review prompts.
- Save prompt context artifacts for each run: prompt-context.json, instructions.md when present, implementation prompts, and review prompts.
- Have `codex-cage init` create `.codex-cage/instructions.md` only when missing.
- Keep generated context indexing out of scope.

## Validation

- npm run typecheck
- npm test
- npm run qa
- npm run format
- npm --cache /tmp/codex-cage-npm-cache pack --dry-run
- git diff --check