### PR TITLE
Publish multi-arch base image

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -6,7 +6,7 @@ on:
       image_version:
         description: Image version tag to publish.
         required: true
-        default: "0.1.0"
+        default: "0.1.1"
       codex_cli_version:
         description: Exact @openai/codex version to install.
         required: true
@@ -41,6 +41,9 @@ jobs:
             echo "CODEX_CLI_VERSION=${{ inputs.codex_cli_version }}" >> "$GITHUB_ENV"
           fi
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -57,6 +60,7 @@ jobs:
           context: docker/base
           file: docker/base/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             CODEX_CLI_VERSION=${{ env.CODEX_CLI_VERSION }}
           tags: |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Codex Cage prepares disposable Docker resources per run:
 
 - A labeled Docker volume for `/workspace`
 - A labeled Docker network for run-local connectivity
-- An agent container using the pinned default image `ghcr.io/jhowliu/codex-cage/base:0.1.0`
+- An agent container using the pinned default image `ghcr.io/jhowliu/codex-cage/base:0.1.1`
 
 The sandbox runs as the non-root `agent` user, clones the target repo into the volume, and does not bind mount the host working tree, Docker socket, SSH config, GitHub CLI config, or host ports.
 

--- a/docker/base/README.md
+++ b/docker/base/README.md
@@ -5,7 +5,7 @@ The base image is the minimal runtime for Codex Cage agent containers.
 Published image:
 
 ```text
-ghcr.io/jhowliu/codex-cage/base:0.1.0
+ghcr.io/jhowliu/codex-cage/base:0.1.1
 ```
 
 The CLI should use immutable version tags for reproducible runs. The `latest` tag is published only as a manual testing convenience.
@@ -44,4 +44,4 @@ ghcr.io/jhowliu/codex-cage/base:<version>
 ghcr.io/jhowliu/codex-cage/base:latest
 ```
 
-Publishing is available through manual workflow dispatch and tags shaped like `base-v0.1.0`.
+Publishing is available through manual workflow dispatch and tags shaped like `base-v0.1.1`. Published images include `linux/amd64` and `linux/arm64` manifests.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -85,7 +85,7 @@ services:
     - pg_isready -h db -U postgres
 
 runtime:
-  image: ghcr.io/jhowliu/codex-cage/base:0.1.0
+  image: ghcr.io/jhowliu/codex-cage/base:0.1.1
   dockerfile: null
 
 agent:
@@ -181,14 +181,14 @@ Non-goals:
 The base agent image is defined in `docker/base/Dockerfile` and published to GHCR:
 
 ```text
-ghcr.io/jhowliu/codex-cage/base:0.1.0
+ghcr.io/jhowliu/codex-cage/base:0.1.1
 ```
 
 The image is intentionally orchestration-only. It includes Node.js/npm, a pinned `@openai/codex` CLI, `git`, GitHub CLI `gh`, `curl`, `jq`, certificates, OpenSSH client, the non-root `agent` user, and `/workspace`. It does not include Docker CLI, Python, Go, Rust, Java, native build toolchains, database clients, browser tooling, `tini`, or a custom entrypoint.
 
 Target repositories that need language runtimes or system packages should use `codex-cage init --dockerfile` and add those dependencies in `.codex-cage/Dockerfile`.
 
-The publish workflow supports manual dispatch and tags shaped like `base-v0.1.0`. It publishes both the immutable version tag and `latest`, but runtime defaults should use version tags.
+The publish workflow supports manual dispatch and tags shaped like `base-v0.1.1`. It publishes both the immutable version tag and `latest`, but runtime defaults should use version tags. Published images include `linux/amd64` and `linux/arm64` manifests.
 
 Local image validation is opt-in because it requires Docker and network access:
 

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -74,7 +74,7 @@ export type CleanupDockerReport = {
   skippedActiveRunIds: string[];
 };
 
-export const defaultSandboxImage = "ghcr.io/jhowliu/codex-cage/base:0.1.0";
+export const defaultSandboxImage = "ghcr.io/jhowliu/codex-cage/base:0.1.1";
 export const defaultWorkspacePath = "/workspace";
 
 const runIdLabelName = "codex-cage.run_id";

--- a/src/init.ts
+++ b/src/init.ts
@@ -28,7 +28,7 @@ services:
   ready: []
 
 runtime:
-  image: ghcr.io/jhowliu/codex-cage/base:0.1.0
+  image: ghcr.io/jhowliu/codex-cage/base:0.1.1
   dockerfile: null
 
 agent:
@@ -63,7 +63,7 @@ GITHUB_TOKEN=
 LINEAR_API_KEY=
 `;
 
-const dockerfile = `FROM ghcr.io/jhowliu/codex-cage/base:0.1.0
+const dockerfile = `FROM ghcr.io/jhowliu/codex-cage/base:0.1.1
 
 # Add target-repo system dependencies here.
 `;

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -26,7 +26,7 @@ test("init creates config, env example, and gitignore entries", async () => {
     assert.match(config, /verify:/);
     assert.match(config, /Replace this with your real test command/);
     assert.match(config, /runtime:/);
-    assert.match(config, /ghcr\.io\/jhowliu\/codex-cage\/base:0\.1\.0/);
+    assert.match(config, /ghcr\.io\/jhowliu\/codex-cage\/base:0\.1\.1/);
 
     const envExample = await readFile(join(cwd, ".codex-cage.env.example"), "utf8");
     assert.match(envExample, /OPENAI_API_KEY=/);
@@ -90,7 +90,7 @@ test("init can create optional Dockerfile", async () => {
 
     assert.ok(result.created.includes(".codex-cage/Dockerfile"));
     const dockerfile = await readFile(join(cwd, ".codex-cage", "Dockerfile"), "utf8");
-    assert.match(dockerfile, /FROM ghcr\.io\/jhowliu\/codex-cage\/base:0\.1\.0/);
+    assert.match(dockerfile, /FROM ghcr\.io\/jhowliu\/codex-cage\/base:0\.1\.1/);
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Publish the base image for both linux/amd64 and linux/arm64 using QEMU and Buildx platforms.
- Bump the default Codex Cage base image reference to ghcr.io/jhowliu/codex-cage/base:0.1.1 because 0.1.0 was published amd64-only.
- Update init defaults and docs for the new base image tag.

## Validation

- npm run typecheck
- npm test
- npm run qa
- npm run format
- npm --cache /tmp/codex-cage-npm-cache pack --dry-run
- git diff --check

## Follow-up

After merging, run the base-image workflow with image_version=0.1.1 and retry the disposable codex-cage run smoke test on arm64.