### PR TITLE
Mount Codex OAuth auth for sandbox runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Codex Cage uses a per-run Compose project name, starts services with `docker com
 
 ## Secret Guards
 
-Local secrets live in `.codex-cage.env`, which is parsed by the orchestrator and passed to Docker as process environment, not mounted into the container or written into command arguments. Known secret values are redacted from logs.
+Local secrets live in `.codex-cage.env`, which is parsed by the orchestrator and passed to Docker as process environment, not written into command arguments. If `OPENAI_API_KEY` is not set and `~/.codex/auth.json` exists, Codex Cage mounts only that Codex OAuth auth file read-only into the agent container. Known secret values are redacted from logs.
 
 Guard scanning checks diffs for injected secret values, high-confidence token patterns, private key material, and sensitive auth files such as `.env`, `.codex-cage.env`, `.npmrc`, `.ssh/*`, `.config/gh/*`, and `.aws/*`. Sample env files like `.env.example`, `.env.sample`, and `.env.template` are allowed, but their added content is still scanned for secret-looking values.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -34,7 +34,7 @@ GITHUB_TOKEN=...
 LINEAR_API_KEY=...
 ```
 
-`LINEAR_API_KEY` is required only for Linear issue URLs. `.codex-cage.env` is ignored by `codex-cage init` and must not be committed.
+`OPENAI_API_KEY` is optional when the host has Codex OAuth credentials at `~/.codex/auth.json`; Codex Cage mounts only that file read-only into the agent container. `LINEAR_API_KEY` is required only for Linear issue URLs. `.codex-cage.env` is ignored by `codex-cage init` and must not be committed.
 
 ### GitHub Token Permissions
 

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -18,6 +18,12 @@ export type DockerRunOptions = {
   env?: Record<string, string>;
 };
 
+export type DockerBindMount = {
+  source: string;
+  target: string;
+  readonly: boolean;
+};
+
 export type DockerSandboxOptions = {
   runId: string;
   cloneUrl: string;
@@ -26,6 +32,7 @@ export type DockerSandboxOptions = {
   serviceNetworkName?: string;
   labels?: Record<string, string>;
   env?: Record<string, string>;
+  mounts?: DockerBindMount[];
 };
 
 export type DockerSandbox = {
@@ -113,6 +120,7 @@ export function createDockerSandbox(
   const { volumeName, networkName } = dockerResourceNames(options.runId);
   const ownedNetworkName = options.serviceNetworkName === undefined ? networkName : null;
   const agentNetworkName = options.serviceNetworkName ?? networkName;
+  const mounts = options.mounts ?? [];
   const labels = {
     [runIdLabelName]: options.runId,
     ...options.labels,
@@ -140,6 +148,7 @@ export function createDockerSandbox(
           workspacePath,
           labels,
           env: options.env ?? {},
+          mounts,
           command: `git clone ${shellQuote(options.cloneUrl)} .`,
         }),
         { env: options.env ?? {} },
@@ -154,6 +163,7 @@ export function createDockerSandbox(
           workspacePath,
           labels,
           env: options.env ?? {},
+          mounts,
           command,
         }),
         { env: options.env ?? {} },
@@ -318,6 +328,7 @@ type DockerRunArgsInput = {
   workspacePath: string;
   labels: Record<string, string>;
   env: Record<string, string>;
+  mounts?: DockerBindMount[];
   command: string;
 };
 
@@ -330,6 +341,7 @@ export function dockerRunArgs(input: DockerRunArgsInput): string[] {
     input.networkName,
     "--mount",
     `type=volume,source=${input.volumeName},target=${input.workspacePath}`,
+    ...bindMountArgs(input.mounts ?? []),
     "--workdir",
     input.workspacePath,
     "--user",
@@ -340,6 +352,18 @@ export function dockerRunArgs(input: DockerRunArgsInput): string[] {
     "-lc",
     input.command,
   ];
+}
+
+function bindMountArgs(mounts: DockerBindMount[]): string[] {
+  return mounts.flatMap((mount) => [
+    "--mount",
+    [
+      "type=bind",
+      `source=${mount.source}`,
+      `target=${mount.target}`,
+      ...(mount.readonly ? ["readonly"] : []),
+    ].join(","),
+  ]);
 }
 
 function labelArgs(labels: Record<string, string>): string[] {

--- a/src/init.ts
+++ b/src/init.ts
@@ -57,6 +57,7 @@ guards:
 `;
 
 const envExample = `# Copy this file to .codex-cage.env and fill in local secrets.
+# OPENAI_API_KEY is optional when using host Codex OAuth auth from ~/.codex/auth.json.
 OPENAI_API_KEY=
 GITHUB_TOKEN=
 # Required only for Linear issue URLs.

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,4 +1,5 @@
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { execa } from "execa";
 import YAML from "yaml";
@@ -12,6 +13,7 @@ import {
   buildRuntimeImage,
   createDockerSandbox,
   dockerRunArgs,
+  type DockerBindMount,
   type DockerSandbox,
   type DockerSandboxOptions,
   type RuntimeImageBuildResult,
@@ -92,6 +94,7 @@ export type RunCodexCageDependencies = {
   runIndependentReview?: typeof runIndependentReview;
   publishSuccessfulRun?: typeof publishSuccessfulRun;
   generateRunId?: () => string;
+  resolveCodexAuthMount?: typeof resolveCodexAuthMount;
 };
 
 type RuntimeContext = {
@@ -109,6 +112,7 @@ type RuntimeContext = {
   branchName: string;
   runtimeImage: RuntimeImageBuildResult & { source: "configured" | "built" };
   promptContext: PromptContext;
+  codexAuthMount: DockerBindMount | null;
 };
 
 type PhaseBody = () => Promise<string | undefined>;
@@ -229,6 +233,10 @@ export async function runCodexCage(
       env: context.secrets,
     };
 
+    if (context.codexAuthMount !== null) {
+      sandboxOptions.mounts = [context.codexAuthMount];
+    }
+
     if (compose !== null) {
       sandboxOptions.serviceNetworkName = compose.networkName;
     }
@@ -308,6 +316,7 @@ async function prepareRuntimeContext(
   const resolveRepo = dependencies.resolveTargetRepo ?? resolveTargetRepo;
   const authenticateRepo =
     dependencies.createAuthenticatedRepo ?? createAuthenticatedRepo;
+  const findCodexAuthMount = dependencies.resolveCodexAuthMount ?? resolveCodexAuthMount;
   const secrets = normalizeRuntimeEnv(await readEnv(cwd));
   const issueOptions: Parameters<typeof fetchIssueContext>[1] = {
     comments: configResult.config.issue.comments,
@@ -345,6 +354,7 @@ async function prepareRuntimeContext(
     source: "configured" as const,
   };
   const promptContext = await buildPromptContext(cwd);
+  const codexAuthMount = await findCodexAuthMount(secrets);
 
   return {
     cwd,
@@ -361,6 +371,32 @@ async function prepareRuntimeContext(
     branchName,
     runtimeImage,
     promptContext,
+    codexAuthMount,
+  };
+}
+
+export async function resolveCodexAuthMount(
+  secrets: Record<string, string>,
+  authPath = resolve(homedir(), ".codex", "auth.json"),
+): Promise<DockerBindMount | null> {
+  if (hasUsableSecret(secrets.OPENAI_API_KEY)) {
+    return null;
+  }
+
+  try {
+    await access(authPath);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return null;
+    }
+
+    throw error;
+  }
+
+  return {
+    source: authPath,
+    target: "/home/agent/.codex/auth.json",
+    readonly: true,
   };
 }
 
@@ -391,14 +427,22 @@ async function readConfig(cwd: string): Promise<{
 }
 
 function normalizeRuntimeEnv(env: Record<string, string>): Record<string, string> {
-  if (env.GITHUB_TOKEN === undefined || env.GH_TOKEN !== undefined) {
-    return env;
+  const nonEmptyEnv = Object.fromEntries(
+    Object.entries(env).filter(([, value]) => value.trim() !== ""),
+  );
+
+  if (nonEmptyEnv.GITHUB_TOKEN === undefined || nonEmptyEnv.GH_TOKEN !== undefined) {
+    return nonEmptyEnv;
   }
 
   return {
-    ...env,
-    GH_TOKEN: env.GITHUB_TOKEN,
+    ...nonEmptyEnv,
+    GH_TOKEN: nonEmptyEnv.GITHUB_TOKEN,
   };
+}
+
+function hasUsableSecret(value: string | undefined): boolean {
+  return value !== undefined && value.trim() !== "";
 }
 
 async function runImplementationLoop(input: {

--- a/test/docker.test.ts
+++ b/test/docker.test.ts
@@ -113,6 +113,32 @@ test("dockerRunArgs uses volume workspace and avoids host-sensitive mounts", () 
   assert.deepEqual(args.slice(-3), ["sh", "-lc", "npm test"]);
 });
 
+test("dockerRunArgs supports a single read-only Codex auth file mount", () => {
+  const args = dockerRunArgs({
+    image: defaultSandboxImage,
+    networkName: "codex-cage-run-1",
+    volumeName: "codex-cage-run-1-workspace",
+    workspacePath: "/workspace",
+    labels: { "codex-cage.run_id": "run-1" },
+    env: {},
+    mounts: [
+      {
+        source: "/Users/me/.codex/auth.json",
+        target: "/home/agent/.codex/auth.json",
+        readonly: true,
+      },
+    ],
+    command: "codex exec test",
+  });
+
+  assert.equal(
+    args.includes(
+      "type=bind,source=/Users/me/.codex/auth.json,target=/home/agent/.codex/auth.json,readonly",
+    ),
+    true,
+  );
+});
+
 test("dockerBuildArgs labels per-run runtime images", () => {
   assert.deepEqual(
     dockerBuildArgs({

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -30,6 +30,7 @@ test("init creates config, env example, and gitignore entries", async () => {
 
     const envExample = await readFile(join(cwd, ".codex-cage.env.example"), "utf8");
     assert.match(envExample, /OPENAI_API_KEY=/);
+    assert.match(envExample, /Codex OAuth auth/);
     assert.match(envExample, /GITHUB_TOKEN=/);
 
     const instructions = await readFile(

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -12,7 +12,7 @@ import type { IssueContext } from "../src/issue.js";
 import type { CommandResult, PublishSuccessfulRunInput } from "../src/publish.js";
 import type { GithubRepo, RepoResolution } from "../src/repo.js";
 import type { ReviewReport, RunIndependentReviewResult } from "../src/review.js";
-import { runCodexCage, type ShellRunner } from "../src/run.js";
+import { resolveCodexAuthMount, runCodexCage, type ShellRunner } from "../src/run.js";
 import { openRunStore } from "../src/state.js";
 
 const repo: GithubRepo = {
@@ -137,7 +137,7 @@ verify:
       },
       {
         generateRunId: () => "run-test-123",
-        readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
+        readEnv: async () => ({ GITHUB_TOKEN: "token-value", OPENAI_API_KEY: "" }),
         fetchIssueContext: async () => issue,
         resolveTargetRepo: async () => repoResolution,
         createAuthenticatedRepo: () => ({
@@ -151,6 +151,11 @@ verify:
           sandboxOptions.push(options);
           return fakeSandbox(events);
         },
+        resolveCodexAuthMount: async () => ({
+          source: "/Users/me/.codex/auth.json",
+          target: "/home/agent/.codex/auth.json",
+          readonly: true,
+        }),
         createShellRunner: () => shell,
         runIndependentReview: async (input) => {
           reviewIssueContext = input.issueContext;
@@ -181,6 +186,13 @@ verify:
       GH_TOKEN: "token-value",
       GITHUB_TOKEN: "token-value",
     });
+    assert.deepEqual(sandboxOptions[0]?.mounts, [
+      {
+        source: "/Users/me/.codex/auth.json",
+        target: "/home/agent/.codex/auth.json",
+        readonly: true,
+      },
+    ]);
     assert.equal(published.length, 1);
     assert.equal(published[0]?.metadata.verification[0], "`npm test` passed");
 
@@ -211,6 +223,28 @@ verify:
       details.phases.map((phase) => phase.name),
       ["preflight", "cloning", "implement", "verify", "review", "pr"],
     );
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("resolveCodexAuthMount uses host Codex OAuth auth only without API key", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "codex-cage-auth-"));
+  const authPath = join(cwd, "auth.json");
+
+  try {
+    await writeFile(authPath, "{}", "utf8");
+
+    assert.deepEqual(await resolveCodexAuthMount({}, authPath), {
+      source: authPath,
+      target: "/home/agent/.codex/auth.json",
+      readonly: true,
+    });
+    assert.equal(
+      await resolveCodexAuthMount({ OPENAI_API_KEY: "sk-test" }, authPath),
+      null,
+    );
+    assert.equal(await resolveCodexAuthMount({}, join(cwd, "missing.json")), null);
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Fall back to host Codex OAuth auth when `OPENAI_API_KEY` is not set.
- Mount only `~/.codex/auth.json` read-only at `/home/agent/.codex/auth.json`; do not mount the full Codex directory or config.
- Filter empty `.codex-cage.env` placeholder values before Docker env injection, so `OPENAI_API_KEY=` does not mask OAuth auth.
- Document the auth fallback in README, workflow docs, and init env example.

## Validation

- npm run typecheck
- npm test
- npm run qa
- npm run format
- npm --cache /tmp/codex-cage-npm-cache pack --dry-run
- git diff --check

## Stacking

This is stacked on #36 because the current smoke test needs the multi-arch `0.1.1` base image and the auth mount fallback.