### PR TITLE
Enforce structured review output

### DIFF
--- a/src/review.ts
+++ b/src/review.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { execa } from "execa";
 import { z } from "zod";
 
@@ -25,6 +28,7 @@ export type ReviewAgentRunInput = {
   cwd: string;
   model: string;
   prompt: string;
+  outputSchema: Record<string, unknown>;
   env?: Record<string, string> | undefined;
 };
 
@@ -99,17 +103,82 @@ const reviewReportSchema = z
     }
   });
 
+export const reviewReportJsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["decision", "summary", "findings"],
+  properties: {
+    decision: {
+      type: "string",
+      enum: ["pass", "blocking"],
+    },
+    summary: {
+      type: "string",
+      minLength: 1,
+    },
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["severity", "message"],
+        properties: {
+          severity: {
+            type: "string",
+            enum: ["blocking", "non_blocking"],
+          },
+          message: {
+            type: "string",
+            minLength: 1,
+          },
+          path: {
+            type: "string",
+            minLength: 1,
+          },
+          line: {
+            type: "integer",
+            minimum: 1,
+          },
+        },
+      },
+    },
+  },
+} as const satisfies Record<string, unknown>;
+
 export const execaReviewAgentRunner: ReviewAgentRunner = {
   async run(input: ReviewAgentRunInput): Promise<string> {
-    const args = ["exec", "--model", input.model, "--cwd", input.cwd, input.prompt];
+    const tempDirectory = await mkdtemp(join(tmpdir(), "codex-cage-review-"));
+    const outputSchemaPath = join(tempDirectory, "review-output-schema.json");
 
-    if (input.env === undefined) {
-      const result = await execa("codex", args);
+    try {
+      await writeFile(
+        outputSchemaPath,
+        `${JSON.stringify(input.outputSchema, null, 2)}\n`,
+        "utf8",
+      );
+      const args = [
+        "exec",
+        "--model",
+        input.model,
+        "--sandbox",
+        "read-only",
+        "--cd",
+        input.cwd,
+        "--output-schema",
+        outputSchemaPath,
+        input.prompt,
+      ];
+
+      if (input.env === undefined) {
+        const result = await execa("codex", args);
+        return result.stdout;
+      }
+
+      const result = await execa("codex", args, { env: input.env });
       return result.stdout;
+    } finally {
+      await rm(tempDirectory, { recursive: true, force: true });
     }
-
-    const result = await execa("codex", args, { env: input.env });
-    return result.stdout;
   },
 };
 
@@ -122,6 +191,7 @@ export async function runIndependentReview(
     cwd: input.cwd,
     model: input.model,
     prompt,
+    outputSchema: reviewReportJsonSchema,
     env: input.env,
   });
   const currentDiff = await input.readCurrentDiff();
@@ -230,7 +300,7 @@ export function blockingReviewFeedback(report: ReviewReport): string {
 }
 
 function extractJsonObject(output: string): string {
-  const fencedJson = output.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1]?.trim();
+  const fencedJson = output.match(/```json\s*([\s\S]*?)```/i)?.[1]?.trim();
 
   if (fencedJson !== undefined) {
     return fencedJson;

--- a/src/run.ts
+++ b/src/run.ts
@@ -872,13 +872,19 @@ function shellCommandRunner(shell: ShellRunner, executable: string): CommandRunn
 function reviewAgentRunner(shell: ShellRunner): ReviewAgentRunner {
   return {
     async run(input): Promise<string> {
+      const outputSchemaPath = "/tmp/codex-cage-review-output-schema.json";
+      const writeOutputSchemaCommand = `printf %s ${shellQuote(
+        JSON.stringify(input.outputSchema),
+      )} > ${shellQuote(outputSchemaPath)}`;
+
       return await requiredShell(
         shell,
-        codexExecCommand({
+        `${writeOutputSchemaCommand} && ${codexExecCommand({
           model: input.model,
           sandbox: "read-only",
+          outputSchemaPath,
           prompt: input.prompt,
-        }),
+        })}`,
       );
     },
   };
@@ -977,16 +983,24 @@ ${comments}
 function codexExecCommand(input: {
   model: string;
   sandbox: "read-only" | "workspace-write";
+  outputSchemaPath?: string | undefined;
   prompt: string;
 }): string {
-  return [
+  const args = [
     "codex exec",
     "--model",
     shellQuote(input.model),
     "--sandbox",
     shellQuote(input.sandbox),
-    shellQuote(input.prompt),
-  ].join(" ");
+  ];
+
+  if (input.outputSchemaPath !== undefined) {
+    args.push("--output-schema", shellQuote(input.outputSchemaPath));
+  }
+
+  args.push(shellQuote(input.prompt));
+
+  return args.join(" ");
 }
 
 function generateRunId(): string {

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -76,6 +76,17 @@ test("parseReviewReport accepts strict structured JSON from the review agent", (
   });
 });
 
+test("parseReviewReport ignores non-json fenced blocks before JSON", () => {
+  assert.deepEqual(
+    parseReviewReport(`\n\`\`\`bash\n-code\n\`\`\`\n\n${passReportJson}\n`),
+    {
+      decision: "pass",
+      summary: "No blocking issues.",
+      findings: [],
+    },
+  );
+});
+
 test("parseReviewReport rejects passing reports with blocking findings", () => {
   assert.throws(
     () =>
@@ -156,6 +167,12 @@ test("runIndependentReview runs a fresh review runner and returns parsed action"
   assert.equal(runner.calls.length, 1);
   assert.equal(runner.calls[0]?.cwd, "/repo");
   assert.equal(runner.calls[0]?.model, "gpt-5.4");
+  assert.equal(runner.calls[0]?.outputSchema.type, "object");
+  assert.deepEqual(runner.calls[0]?.outputSchema.required, [
+    "decision",
+    "summary",
+    "findings",
+  ]);
   assert.deepEqual(runner.calls[0]?.env, { OPENAI_API_KEY: "secret" });
   assert.equal(result.report.decision, "pass");
   assert.deepEqual(result.nextAction, { action: "continue" });


### PR DESCRIPTION
## Summary

- Add a JSON Schema for independent review reports.
- Run review agents with Codex CLI `--output-schema` so review output is constrained at generation time.
- Write the schema to temp storage for local review runs and to `/tmp` inside Docker review runs, avoiding repo diff changes.
- Keep Zod validation and JSON extraction as a defensive fallback.
- Fix JSON fence extraction so non-JSON fenced blocks are ignored.

## Validation

- npm run format
- npm run typecheck
- npm test
- git diff --check