### PR TITLE
Fix structured review output schema

### DIFF
--- a/src/review.ts
+++ b/src/review.ts
@@ -69,10 +69,22 @@ const reviewFindingSchema = z
   .object({
     severity: z.enum(["blocking", "non_blocking"]),
     message: z.string().min(1),
-    path: z.string().min(1).optional(),
-    line: z.number().int().positive().optional(),
+    path: z.string().min(1).nullable().optional(),
+    line: z.number().int().positive().nullable().optional(),
   })
-  .strict();
+  .strict()
+  .transform((finding): ReviewFinding => {
+    return {
+      severity: finding.severity,
+      message: finding.message,
+      ...(finding.path === null || finding.path === undefined
+        ? {}
+        : { path: finding.path }),
+      ...(finding.line === null || finding.line === undefined
+        ? {}
+        : { line: finding.line }),
+    };
+  });
 
 const reviewReportSchema = z
   .object({
@@ -121,7 +133,7 @@ export const reviewReportJsonSchema = {
       items: {
         type: "object",
         additionalProperties: false,
-        required: ["severity", "message"],
+        required: ["severity", "message", "path", "line"],
         properties: {
           severity: {
             type: "string",
@@ -132,12 +144,10 @@ export const reviewReportJsonSchema = {
             minLength: 1,
           },
           path: {
-            type: "string",
-            minLength: 1,
+            type: ["string", "null"],
           },
           line: {
-            type: "integer",
-            minimum: 1,
+            type: ["integer", "null"],
           },
         },
       },
@@ -227,8 +237,8 @@ Return only JSON matching this schema:
     {
       "severity": "blocking" | "non_blocking",
       "message": "specific finding",
-      "path": "optional/file/path",
-      "line": 123
+      "path": "optional/file/path or null",
+      "line": 123 or null
     }
   ]
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -877,15 +877,19 @@ function reviewAgentRunner(shell: ShellRunner): ReviewAgentRunner {
         JSON.stringify(input.outputSchema),
       )} > ${shellQuote(outputSchemaPath)}`;
 
-      return await requiredShell(
-        shell,
-        `${writeOutputSchemaCommand} && ${codexExecCommand({
-          model: input.model,
-          sandbox: "read-only",
-          outputSchemaPath,
-          prompt: input.prompt,
-        })}`,
-      );
+      const command = `${writeOutputSchemaCommand} && ${codexExecCommand({
+        model: input.model,
+        sandbox: "read-only",
+        outputSchemaPath,
+        prompt: input.prompt,
+      })}`;
+      const result = await shell.run(command);
+
+      if (result.exitCode !== 0) {
+        throw new Error(formatCommandLog(command, result));
+      }
+
+      return result.stdout;
     },
   };
 }

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -4,6 +4,7 @@ import {
   blockingReviewFeedback,
   buildReviewPrompt,
   parseReviewReport,
+  reviewReportJsonSchema,
   reviewNextAction,
   runIndependentReview,
   type ReviewAgentRunner,
@@ -85,6 +86,44 @@ test("parseReviewReport ignores non-json fenced blocks before JSON", () => {
       findings: [],
     },
   );
+});
+
+test("parseReviewReport normalizes nullable structured output fields", () => {
+  assert.deepEqual(
+    parseReviewReport(
+      JSON.stringify({
+        decision: "blocking",
+        summary: "Needs a fix.",
+        findings: [
+          {
+            severity: "blocking",
+            message: "Missing required behavior.",
+            path: null,
+            line: null,
+          },
+        ],
+      }),
+    ),
+    {
+      decision: "blocking",
+      summary: "Needs a fix.",
+      findings: [
+        {
+          severity: "blocking",
+          message: "Missing required behavior.",
+        },
+      ],
+    },
+  );
+});
+
+test("review report JSON schema requires every finding property", () => {
+  assert.deepEqual(reviewReportJsonSchema.properties.findings.items.required, [
+    "severity",
+    "message",
+    "path",
+    "line",
+  ]);
 });
 
 test("parseReviewReport rejects passing reports with blocking findings", () => {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -104,6 +104,80 @@ function passingReview(): RunIndependentReviewResult {
   };
 }
 
+test("runCodexCage parses review agent stdout without command log noise", async () => {
+  const cwd = await createProject(`
+verify:
+  - npm test
+`);
+  const events: string[] = [];
+  const reviewJson = JSON.stringify({
+    decision: "pass",
+    summary: "No blocking issues.",
+    findings: [],
+  });
+  const diff = `diff --git a/src/app.ts b/src/app.ts
+@@ -1 +1,2 @@
+ export const ok = true;
++export const changed = true;
+`;
+  const shell = shellRunner(
+    new Map([
+      ["git fetch origin", commandResult()],
+      ["--sandbox 'workspace-write'", commandResult("implemented")],
+      ["--sandbox 'read-only'", commandResult(reviewJson)],
+      ["npm test", commandResult("tests passed")],
+      ["git add --intent-to-add", commandResult(diff)],
+    ]),
+  );
+
+  try {
+    const result = await runCodexCage(
+      {
+        cwd,
+        issueUrl: issue.url,
+      },
+      {
+        generateRunId: () => "run-review-stdout",
+        readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
+        findCodexAuthFile: async () => null,
+        fetchIssueContext: async () => issue,
+        resolveTargetRepo: async () => repoResolution,
+        createAuthenticatedRepo: () => ({
+          repo,
+          cloneUrl:
+            "https://x-access-token:token-value@github.com/jhowliu/codex-cage.git",
+          redactedCloneUrl:
+            "https://x-access-token:[REDACTED]@github.com/jhowliu/codex-cage.git",
+        }),
+        createDockerSandbox: () => fakeSandbox(events),
+        createShellRunner: () => shell,
+        publishSuccessfulRun: async (input) => ({
+          branchName: input.branchName ?? "codex-cage/gh-26-run-test",
+          commitMessage: "#26 Wire run command",
+          prTitle: "#26 Wire run command",
+          prBody: "body",
+          prUrl: "https://github.com/jhowliu/codex-cage/pull/26",
+        }),
+      },
+    );
+
+    const reviewLog = await readFile(
+      join(cwd, ".codex-cage", "runs", "run-review-stdout", "review.log"),
+      "utf8",
+    );
+
+    assert.equal(result.status, "succeeded");
+    assert.doesNotMatch(reviewLog, /^\$ printf/);
+    assert.deepEqual(JSON.parse(reviewLog), {
+      decision: "pass",
+      summary: "No blocking issues.",
+      findings: [],
+    });
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
 test("runCodexCage executes the happy path and records a successful run", async () => {
   const cwd = await createProject(`
 verify:


### PR DESCRIPTION
## Summary
- make review finding path/line required-but-nullable in the Codex output schema
- normalize null path/line back to the existing optional ReviewFinding shape
- add regression coverage for the schema requirement and nullable structured output

## Validation
- npm run format
- npm run typecheck
- npm test
- git diff --check

Fixes the review failure from run-20260425115833-t2u59n: OpenAI structured outputs require every object property to be listed in required.