### PR TITLE
#35  Document positional issue URL usage for codex-cage run

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Full setup, token, configuration, security, and QA details live in [docs/workflo
 codex-cage --help
 codex-cage init
 codex-cage init --dockerfile
-codex-cage run --issue <url>
+codex-cage run <url>
 codex-cage runs list
 codex-cage runs show <run-id>
 codex-cage cleanup
@@ -59,10 +59,12 @@ Run metadata is stored in `.codex-cage/codex-cage.sqlite`. Large artifacts such 
 ## Run an Issue
 
 ```bash
-codex-cage run --issue https://github.com/OWNER/REPO/issues/123
+codex-cage run https://github.com/OWNER/REPO/issues/123
 ```
 
 The `run` command reads `.codex-cage.yml` and `.codex-cage.env`, fetches issue context, resolves the target repo, creates a Docker workspace, starts configured Compose services, runs Codex implementation iterations, verifies configured commands, scans the diff for secrets, runs independent review, and publishes a PR when all gates pass.
+
+Passing the issue URL positionally is preferred. `--issue <url>` remains supported for compatibility.
 
 ## Issue Context
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -142,6 +142,7 @@ codex-cage run https://github.com/OWNER/REPO/issues/123
 ```
 
 GitHub issue URLs infer the target repository. If the current directory has a different GitHub origin, Codex Cage fails unless `--repo OWNER/REPO` is passed explicitly.
+The positional issue URL form is preferred; `--issue <url>` remains supported for compatibility.
 
 Successful runs create one branch, one commit, one push, and one ready PR. GitHub issue PR bodies include a closing keyword such as `Closes #123`, so GitHub closes the issue only after PR merge.
 


### PR DESCRIPTION
## Summary
Implemented #35:  Document positional issue URL usage for codex-cage run

## Verification
- `npm test` passed

## Review
Independent review passed.

## Risks
- None noted.

## Run
- Run ID: run-20260425122032-k6bnf2

## Issue
- https://github.com/jhowliu/codex-cage/issues/35
- Closes #35
