### PR TITLE
#43 Add CLI examples guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Codex Cage is a lightweight CLI for running Codex against issue-driven work in an isolated Docker workspace. The CLI can initialize target repos, run the issue-driven orchestration loop, inspect local run metadata, and clean up managed Docker resources.
 
-Full setup, token, configuration, security, and QA details live in [docs/workflow.md](docs/workflow.md).
+Full setup, token, configuration, security, and QA details live in [docs/workflow.md](docs/workflow.md). For copy-pasteable CLI usage, see [docs/cli-examples.md](docs/cli-examples.md).
 
 ## Current Commands
 
@@ -10,7 +10,7 @@ Full setup, token, configuration, security, and QA details live in [docs/workflo
 codex-cage --help
 codex-cage init
 codex-cage init --dockerfile
-codex-cage run --issue <url>
+codex-cage run <issue-url>
 codex-cage runs list
 codex-cage runs show <run-id>
 codex-cage cleanup
@@ -59,10 +59,12 @@ Run metadata is stored in `.codex-cage/codex-cage.sqlite`. Large artifacts such 
 ## Run an Issue
 
 ```bash
-codex-cage run --issue https://github.com/OWNER/REPO/issues/123
+codex-cage run https://github.com/OWNER/REPO/issues/123
 ```
 
 The `run` command reads `.codex-cage.yml` and `.codex-cage.env`, fetches issue context, resolves the target repo, creates a Docker workspace, starts configured Compose services, runs Codex implementation iterations, verifies configured commands, scans the diff for secrets, runs independent review, and publishes a PR when all gates pass.
+
+See [CLI Examples](docs/cli-examples.md) for GitHub, Linear, override, run inspection, and cleanup examples. The legacy `codex-cage run --issue <url>` form remains available for compatibility.
 
 ## Issue Context
 

--- a/docs/cli-examples.md
+++ b/docs/cli-examples.md
@@ -1,0 +1,95 @@
+# CLI Examples
+
+Common `codex-cage` CLI workflows are shown below with placeholder owners, repos, and issue IDs. Run these commands from the repository where Codex Cage is installed or available on `PATH`.
+
+## Initialize A Repo
+
+Create the default Codex Cage config in a target repository:
+
+```bash
+codex-cage init
+```
+
+Create the config plus a runtime Dockerfile for target repos that need extra system packages:
+
+```bash
+codex-cage init --dockerfile
+```
+
+After initialization, edit `.codex-cage.yml` so `setup` and `verify` match the target repository.
+
+## Run A GitHub Issue
+
+Use the positional issue URL form for GitHub issues:
+
+```bash
+codex-cage run https://github.com/acme/widgets/issues/123
+```
+
+GitHub issue URLs infer the target repository from the URL.
+
+The legacy `--issue <url>` form is still accepted for compatibility:
+
+```bash
+codex-cage run --issue https://github.com/acme/widgets/issues/123
+```
+
+## Run A Linear Issue
+
+Linear issue URLs provide task context, but the target GitHub repository must be resolved separately. Pass `--repo` explicitly when the current directory is not enough:
+
+```bash
+codex-cage run https://linear.app/acme/issue/ENG-123/fix-widget-loading --repo acme/widgets
+```
+
+## Override Model Or Base Branch
+
+Override the configured Codex model for one run:
+
+```bash
+codex-cage run https://github.com/acme/widgets/issues/123 --model gpt-5.5
+```
+
+Override the configured base branch for one run:
+
+```bash
+codex-cage run https://github.com/acme/widgets/issues/123 --base release/2026-04
+```
+
+Use both overrides together:
+
+```bash
+codex-cage run https://github.com/acme/widgets/issues/123 --model gpt-5.5 --base release/2026-04
+```
+
+## List And Show Runs
+
+List local run metadata:
+
+```bash
+codex-cage runs list
+```
+
+Show details for a specific run:
+
+```bash
+codex-cage runs show run_01hv7m3example
+```
+
+Run metadata is stored under `.codex-cage/` in the host repository.
+
+## Cleanup
+
+Remove stopped Codex Cage Docker resources plus inactive run networks and volumes:
+
+```bash
+codex-cage cleanup
+```
+
+Remove all Codex Cage managed Docker resources, including active managed containers:
+
+```bash
+codex-cage cleanup --all
+```
+
+Cleanup does not delete `.codex-cage/runs` artifacts or `.codex-cage/codex-cage.sqlite`.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -4,6 +4,8 @@ Codex Cage runs issue-driven Codex work in Docker-owned workspaces. The CLI is b
 
 The `run` command wires those slices into one orchestration loop. It fetches issue context, clones into a Docker volume, runs setup and verification commands, feeds failures back into Codex for bounded retries, runs an independent read-only review, blocks secret-bearing diffs, and publishes a PR only after all gates pass.
 
+For copy-pasteable command examples, see [CLI Examples](cli-examples.md).
+
 ## Install
 
 From this repository:


### PR DESCRIPTION
## Summary
Implemented #43: Add CLI examples guide

## Verification
- `npm test` passed

## Review
Independent review passed.

## Risks
- None noted.

## Run
- Run ID: run-20260425122905-z0jb1e

## Issue
- https://github.com/jhowliu/codex-cage/issues/43
- Closes #43
