### PR TITLE
#57 P2: Add no-publish dry-run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Review is read-only. If the diff changes during review, the run fails instead of
 
 Successful runs are published by the orchestrator, not by the implementation or review agents. Codex Cage rejects empty diffs, creates a run-specific branch, configures the Codex Cage git author, commits once, pushes without force, and creates a ready GitHub PR by default.
 
+Use `codex-cage run --no-publish ...`, or set `pr.publish: false`, to stop after verification, guard scanning, independent review, and final patch generation. No branch is pushed and no PR is created; the command output points to `.codex-cage/runs/<run-id>/summary.md` and `.codex-cage/runs/<run-id>/final.patch`.
+
 PR bodies include the summary, verification, review status, risks, run id, and issue linkage. GitHub issues use closing keywords such as `Closes #123`; Linear issues are linked without mutating Linear.
 
 ## Cleanup

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -143,7 +143,9 @@ codex-cage run https://github.com/OWNER/REPO/issues/123
 
 GitHub issue URLs infer the target repository. If the current directory has a different GitHub origin, Codex Cage fails unless `--repo OWNER/REPO` is passed explicitly.
 
-Successful runs create one branch, one commit, one push, and one ready PR. GitHub issue PR bodies include a closing keyword such as `Closes #123`, so GitHub closes the issue only after PR merge.
+Successful runs create one branch, one commit, one push, and one ready PR by default. GitHub issue PR bodies include a closing keyword such as `Closes #123`, so GitHub closes the issue only after PR merge.
+
+For security-sensitive inspection runs, pass `--no-publish` or set `pr.publish: false` in `.codex-cage.yml`. Codex Cage still completes verification, guard scanning, independent review, and final artifact generation, then reports that no PR was created and points to `.codex-cage/runs/<run-id>/summary.md` and `.codex-cage/runs/<run-id>/final.patch`.
 
 ## Running Linear Issues
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -46,6 +46,10 @@ export function createCli(dependencies: CliDependencies = {}): Command {
     .option("--base <branch>", "base branch override")
     .option("--model <model>", "Codex model override")
     .option("--draft", "create a draft pull request")
+    .option(
+      "--no-publish",
+      "stop after successful gates and write local artifacts without creating a PR",
+    )
     .action(
       async (
         issueArgument: string | undefined,
@@ -55,6 +59,7 @@ export function createCli(dependencies: CliDependencies = {}): Command {
           base?: string;
           model?: string;
           draft?: boolean;
+          publish?: boolean;
         },
         command: Command,
       ) => {
@@ -73,6 +78,7 @@ export function createCli(dependencies: CliDependencies = {}): Command {
             base: options.base,
             model: options.model,
             draft: options.draft,
+            noPublish: options.publish === false ? true : undefined,
           }),
           {
             onProgress: (event) => {
@@ -94,6 +100,12 @@ export function createCli(dependencies: CliDependencies = {}): Command {
 
         if (result.prUrl !== null) {
           console.log(`${stdoutColor.label("PR")}: ${stdoutColor.link(result.prUrl)}`);
+        } else if (result.status === "succeeded" && result.noPublish === true) {
+          const artifactDir = `.codex-cage/runs/${result.runId}`;
+          console.log(`${stdoutColor.label("PR")}: no PR created (no-publish mode)`);
+          console.log(`${stdoutColor.label("Artifacts")}: ${artifactDir}`);
+          console.log(`${stdoutColor.label("Patch")}: ${artifactDir}/final.patch`);
+          console.log(`${stdoutColor.label("Summary")}: ${artifactDir}/summary.md`);
         }
       },
     );

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,8 +34,9 @@ export const codexCageConfigSchema = z
     pr: z
       .object({
         draft: z.boolean().default(false),
+        publish: z.boolean().default(true),
       })
-      .default(() => ({ draft: false })),
+      .default(() => ({ draft: false, publish: true })),
     git: z
       .object({
         base: z.string().default("main"),

--- a/src/init.ts
+++ b/src/init.ts
@@ -43,6 +43,7 @@ timeouts:
 
 pr:
   draft: false
+  publish: true
 
 git:
   base: main

--- a/src/run.ts
+++ b/src/run.ts
@@ -65,6 +65,7 @@ export type RunCommandOptions = {
   base?: string | undefined;
   model?: string | undefined;
   draft?: boolean | undefined;
+  noPublish?: boolean | undefined;
 };
 
 export type RunCodexCageResult = {
@@ -72,6 +73,7 @@ export type RunCodexCageResult = {
   status: "succeeded" | "failed";
   failureCode: FailureCode | null;
   prUrl: string | null;
+  noPublish?: boolean | undefined;
 };
 
 export type RunProgressEvent =
@@ -139,6 +141,7 @@ type RuntimeContext = {
   baseBranch: string;
   model: string;
   draft: boolean;
+  publish: boolean;
   runId: string;
   branchName: string;
   runtimeImage: RuntimeImageBuildResult & { source: "configured" | "built" };
@@ -402,6 +405,7 @@ async function prepareRuntimeContext(
   const baseBranch = options.base ?? configResult.config.git.base;
   const model = options.model ?? configResult.config.agent.model;
   const draft = options.draft ?? configResult.config.pr.draft;
+  const publish = options.noPublish === true ? false : configResult.config.pr.publish;
   const runId = dependencies.generateRunId?.() ?? generateRunId();
   const branchName = generateBranchName({ issue, runId });
   const runtimeImage = {
@@ -425,6 +429,7 @@ async function prepareRuntimeContext(
     baseBranch,
     model,
     draft,
+    publish,
     runId,
     branchName,
     runtimeImage,
@@ -654,6 +659,47 @@ async function runImplementationLoop(input: {
 
     if (reviewResult.nextAction.action === "fail") {
       throw new RunFailureError("review_blocking", reviewResult.nextAction.feedback);
+    }
+
+    if (!input.context.publish) {
+      const finalPatch = await readCurrentDiff(input.shell);
+
+      if (finalPatch.trim() === "") {
+        throw new NoDiffError();
+      }
+
+      await writeJsonArtifact(input.store, input.context.runId, "pr.json", {
+        created: false,
+        reason: "no_publish",
+        message: "No PR was created because no-publish mode is enabled.",
+      });
+      await input.store.writeArtifact(input.context.runId, "final.patch", finalPatch);
+      await input.store.writeArtifact(
+        input.context.runId,
+        "summary.md",
+        [
+          `# ${input.context.runId}`,
+          "",
+          "No PR was created because no-publish mode is enabled.",
+          "",
+          `Final patch: ${input.store.artifactPath(input.context.runId, "final.patch")}`,
+          `Artifacts: ${input.store.runDirectory(input.context.runId)}`,
+          "",
+        ].join("\n"),
+      );
+      await input.store.updateRunStatus(input.context.runId, {
+        status: "succeeded",
+        prUrl: null,
+        finishedAt: new Date(),
+      });
+
+      return {
+        runId: input.context.runId,
+        status: "succeeded",
+        failureCode: null,
+        prUrl: null,
+        noPublish: true,
+      };
     }
 
     await input.store.updateRunStatus(input.context.runId, { status: "creating_pr" });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -124,6 +124,48 @@ test("run keeps the --issue option for compatibility", async () => {
   ]);
 });
 
+test("run accepts --no-publish", async () => {
+  const calls: RunCommandOptions[] = [];
+  const output: string[] = [];
+  const originalConsoleLog = console.log;
+  const program = createCli({
+    runCodexCage: async (input): Promise<RunCodexCageResult> => {
+      calls.push(input);
+      return {
+        runId: "run-cli-no-publish",
+        status: "succeeded",
+        failureCode: null,
+        prUrl: null,
+        noPublish: true,
+      };
+    },
+  });
+
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => undefined, writeErr: () => undefined });
+  console.log = (message?: unknown) => {
+    output.push(String(message));
+  };
+
+  try {
+    await program.parseAsync(
+      ["run", "https://github.com/jhowliu/codex-cage/issues/35", "--no-publish"],
+      { from: "user" },
+    );
+  } finally {
+    console.log = originalConsoleLog;
+  }
+
+  assert.deepEqual(calls, [
+    {
+      issueUrl: "https://github.com/jhowliu/codex-cage/issues/35",
+      noPublish: true,
+    },
+  ]);
+  assert.match(output.join("\n"), /PR: no PR created \(no-publish mode\)/);
+  assert.match(output.join("\n"), /\.codex-cage\/runs\/run-cli-no-publish\/final\.patch/);
+});
+
 test("runs list and show read local run metadata", async () => {
   const cwd = await mkdtemp(join(tmpdir(), "codex-cage-cli-runs-"));
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -12,6 +12,7 @@ test("config schema accepts a minimal valid config", () => {
   assert.deepEqual(config.verify, ["npm test"]);
   assert.equal(config.git.base, "main");
   assert.equal(config.pr.draft, false);
+  assert.equal(config.pr.publish, true);
   assert.equal(config.issue.comments, 10);
   assert.deepEqual(config.runtime, {
     image: defaultSandboxImage,
@@ -42,6 +43,18 @@ test("config schema accepts explicit runtime image and Dockerfile", () => {
     image: "registry.example.com/codex-cage/base:custom",
     dockerfile: ".codex-cage/Dockerfile",
   });
+});
+
+test("config schema accepts disabling automatic publishing", () => {
+  const config = codexCageConfigSchema.parse({
+    verify: ["npm test"],
+    pr: {
+      publish: false,
+    },
+  });
+
+  assert.equal(config.pr.draft, false);
+  assert.equal(config.pr.publish, false);
 });
 
 test("config schema preserves unknown keys for forward compatibility", () => {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -297,6 +297,153 @@ verify:
   }
 });
 
+test("runCodexCage skips publishing in no-publish mode and keeps final artifacts", async () => {
+  const cwd = await createProject(`
+verify:
+  - npm test
+`);
+  const events: string[] = [];
+  const diff = `diff --git a/src/app.ts b/src/app.ts
+@@ -1 +1,2 @@
+ export const ok = true;
++export const changed = true;
+`;
+  const shell = shellRunner(
+    new Map([
+      ["git fetch origin", commandResult()],
+      ["codex exec", commandResult("implemented")],
+      ["npm test", commandResult("tests passed")],
+      ["git add --intent-to-add", commandResult(diff)],
+    ]),
+  );
+  let publishCalled = false;
+
+  try {
+    const result = await runCodexCage(
+      {
+        cwd,
+        issueUrl: issue.url,
+        noPublish: true,
+      },
+      {
+        generateRunId: () => "run-no-publish",
+        readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
+        findCodexAuthFile: async () => null,
+        fetchIssueContext: async () => issue,
+        resolveTargetRepo: async () => repoResolution,
+        createAuthenticatedRepo: () => ({
+          repo,
+          cloneUrl:
+            "https://x-access-token:token-value@github.com/jhowliu/codex-cage.git",
+          redactedCloneUrl:
+            "https://x-access-token:[REDACTED]@github.com/jhowliu/codex-cage.git",
+        }),
+        createDockerSandbox: () => fakeSandbox(events),
+        createShellRunner: () => shell,
+        runIndependentReview: async () => passingReview(),
+        publishSuccessfulRun: async () => {
+          publishCalled = true;
+          throw new Error("publish should not be called in no-publish mode");
+        },
+      },
+    );
+
+    assert.deepEqual(result, {
+      runId: "run-no-publish",
+      status: "succeeded",
+      failureCode: null,
+      prUrl: null,
+      noPublish: true,
+    });
+    assert.equal(publishCalled, false);
+
+    const store = await openRunStore(cwd);
+    const details = store.getRunDetails("run-no-publish");
+    store.close();
+    const runDirectory = join(cwd, ".codex-cage", "runs", "run-no-publish");
+    const finalPatch = await readFile(join(runDirectory, "final.patch"), "utf8");
+    const summary = await readFile(join(runDirectory, "summary.md"), "utf8");
+    const pr = JSON.parse(await readFile(join(runDirectory, "pr.json"), "utf8"));
+
+    assert.equal(details.run.status, "succeeded");
+    assert.equal(details.run.prUrl, null);
+    assert.deepEqual(
+      details.phases.map((phase) => phase.name),
+      ["preflight", "cloning", "implement", "verify", "review"],
+    );
+    assert.equal(finalPatch, diff);
+    assert.match(summary, /No PR was created because no-publish mode is enabled/);
+    assert.match(summary, /final\.patch/);
+    assert.deepEqual(pr, {
+      created: false,
+      reason: "no_publish",
+      message: "No PR was created because no-publish mode is enabled.",
+    });
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("runCodexCage honors pr.publish false from config", async () => {
+  const cwd = await createProject(`
+verify:
+  - npm test
+pr:
+  publish: false
+`);
+  const diff = `diff --git a/src/app.ts b/src/app.ts
+@@ -1 +1,2 @@
+ export const ok = true;
++export const changed = true;
+`;
+  const shell = shellRunner(
+    new Map([
+      ["git fetch origin", commandResult()],
+      ["codex exec", commandResult("implemented")],
+      ["npm test", commandResult("tests passed")],
+      ["git add --intent-to-add", commandResult(diff)],
+    ]),
+  );
+  let publishCalled = false;
+
+  try {
+    const result = await runCodexCage(
+      {
+        cwd,
+        issueUrl: issue.url,
+      },
+      {
+        generateRunId: () => "run-config-no-publish",
+        readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
+        findCodexAuthFile: async () => null,
+        fetchIssueContext: async () => issue,
+        resolveTargetRepo: async () => repoResolution,
+        createAuthenticatedRepo: () => ({
+          repo,
+          cloneUrl:
+            "https://x-access-token:token-value@github.com/jhowliu/codex-cage.git",
+          redactedCloneUrl:
+            "https://x-access-token:[REDACTED]@github.com/jhowliu/codex-cage.git",
+        }),
+        createDockerSandbox: () => fakeSandbox([]),
+        createShellRunner: () => shell,
+        runIndependentReview: async () => passingReview(),
+        publishSuccessfulRun: async () => {
+          publishCalled = true;
+          throw new Error("publish should not be called when pr.publish is false");
+        },
+      },
+    );
+
+    assert.equal(result.status, "succeeded");
+    assert.equal(result.prUrl, null);
+    assert.equal(result.noPublish, true);
+    assert.equal(publishCalled, false);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
 test("runCodexCage builds configured runtime Dockerfiles before cloning", async () => {
   const cwd = await createProject(`
 verify:


### PR DESCRIPTION
## Summary
Implemented #57: P2: Add no-publish dry-run mode

## Verification
- `npm test` passed

## Review
Independent review passed.

## Risks
- None noted.

## Run
- Run ID: run-20260425151731-wnt5gr

## Issue
- https://github.com/jhowliu/codex-cage/issues/57
- Closes #57
