### PR TITLE
Replace prompt instructions with review policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ codex-cage init
 This creates:
 
 - `.codex-cage.yml`
-- `.codex-cage/instructions.md`
+- `.codex-cage/review-policy.md`
 - `.codex-cage.env.example`
 - `.gitignore` entries for local Codex Cage runtime state
 
@@ -45,7 +45,7 @@ codex-cage init --dockerfile
 
 The generated verify command intentionally fails until replaced with the target repo's real test command.
 
-Codex Cage includes root-level repository instruction files in implementation and review prompts when they exist: `AGENTS.md`, `.codex-cage/instructions.md`, `.github/copilot-instructions.md`, and `CLAUDE.md`. The injected instruction text is capped and saved as run artifacts with the rendered prompts.
+Codex Cage relies on Codex CLI's native `AGENTS.md` handling for repository implementation guidance. It does not inject `AGENTS.md`, `.codex-cage/instructions.md`, `.github/copilot-instructions.md`, or `CLAUDE.md` contents into prompts. Independent review can use `.codex-cage/review-policy.md` for stricter project-specific checks; prompt artifacts record only whether that policy file is present and where the reviewer can read it.
 
 ## Inspect Local Runs
 
@@ -104,13 +104,25 @@ Runtime images are configured in `.codex-cage.yml`. If `runtime.dockerfile` is s
 Target repos can configure Docker Compose services in `.codex-cage.yml`:
 
 ```yaml
+setup:
+  - npm ci
+  - cp .codex-cage/test.env .env
+  - npm run migrate --workspace=server
+
+verify:
+  - npm run test --workspace=server
+
 services:
-  compose: docker-compose.yml
+  compose: .codex-cage/docker-compose.yml
   ready:
-    - pg_isready -h db -U postgres
+    - pg_isready -h postgres -U postgres
 ```
 
 Codex Cage uses a per-run Compose project name, starts services with `docker compose up -d`, attaches the agent container to the Compose network, runs readiness checks from an ephemeral container on that network, and tears services down with `docker compose down -v`.
+
+Compose is host-orchestrated by Codex Cage. Do not mount `/var/run/docker.sock` into the agent container or expect the agent to run Docker itself. Agent commands should reach dependencies through Compose service DNS names such as `postgres`, `redis`, or `minio`; avoid publishing host ports unless the target repo has a specific reason.
+
+For target repo test environment files, prefer a committed non-secret fixture such as `.codex-cage/test.env` and copy it to `.env` during `setup`. That keeps generated `.env` files local while making test credentials and service hostnames easy to review. Do not commit real secrets in these fixture files.
 
 ## Secret Guards
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -60,7 +60,7 @@ codex-cage init
 This creates:
 
 - `.codex-cage.yml`
-- `.codex-cage/instructions.md`
+- `.codex-cage/review-policy.md`
 - `.codex-cage.env.example`
 - `.gitignore` entries for `.codex-cage.env`, run artifacts, and SQLite metadata
 
@@ -74,15 +74,16 @@ codex-cage init --dockerfile
 
 ```yaml
 setup:
-  - npm install
+  - npm ci
+  - cp .codex-cage/test.env .env
 
 verify:
   - npm test
 
 services:
-  compose: docker-compose.yml
+  compose: .codex-cage/docker-compose.yml
   ready:
-    - pg_isready -h db -U postgres
+    - pg_isready -h postgres -U postgres
 
 runtime:
   image: ghcr.io/jhowliu/codex-cage/base:0.1.1
@@ -117,23 +118,57 @@ guards:
 
 `runtime.image` accepts any valid Docker image reference and defaults to the Codex Cage GHCR base image. If `runtime.dockerfile` is set, Codex Cage builds a labeled per-run image before cloning the target repository. The first version uses `.codex-cage/` as the Docker build context, so target runtime Dockerfiles should keep package-install inputs inside that directory.
 
+## Docker Compose Services
+
+Compose services are started by the host-side Codex Cage orchestrator, not by the implementation agent. Codex Cage runs `docker compose up -d` with a per-run project name, attaches the agent container to the Compose network, runs each `services.ready` command from a short-lived container on that same network, and tears services down with `docker compose down -v`.
+
+This keeps the agent boundary simple:
+
+- Do not mount `/var/run/docker.sock` into the agent container.
+- Do not rely on host ports for agent-to-service traffic.
+- Use Compose service DNS names in target repo env files, such as `postgres`, `redis`, `minio`, or whatever service names the Compose file declares.
+- Keep services private by default; publish host ports only when a target repo explicitly needs them.
+
+Target repos that need an `.env` file for tests should prefer a committed, non-secret fixture copied during `setup`:
+
+```yaml
+setup:
+  - npm ci
+  - cp .codex-cage/test.env .env
+  - npm run migrate --workspace=server
+
+services:
+  compose: .codex-cage/docker-compose.yml
+  ready:
+    - pg_isready -h postgres -U postgres
+```
+
+Example `.codex-cage/test.env`:
+
+```dotenv
+NODE_ENV=test
+DATABASE_URL=postgresql://postgres:postgres@postgres:5432/app_test
+REDIS_URL=redis://redis:6379
+MINIO_ENDPOINT=minio
+```
+
+This is clearer than embedding a long inline script in `.codex-cage.yml`, and it keeps generated `.env` files untracked. Fixture env files must contain only local test credentials; real secrets belong in `.codex-cage.env`.
+
+When a Compose file lives under `.codex-cage/`, Codex Cage still runs Compose with the target repo as the project directory. Relative bind mounts like `./scripts/init.sql:/docker-entrypoint-initdb.d/init.sql:ro` resolve from the repo root during `codex-cage run`. If you run the same Compose file manually, pass `--project-directory <repo-root>` to match Codex Cage's behavior.
+
 ## Prompt Instructions
 
-Codex Cage injects root-level repository instruction files into implementation and review prompts when they exist:
+Codex Cage relies on Codex CLI's native `AGENTS.md` handling for repository implementation guidance. It does not inject the contents of `AGENTS.md`, `.codex-cage/instructions.md`, `.github/copilot-instructions.md`, or `CLAUDE.md` into implementation or review prompts.
 
-- `AGENTS.md`
-- `.codex-cage/instructions.md`
-- `.github/copilot-instructions.md`
-- `CLAUDE.md`
-
-Instruction injection is capped at 32 KB total. Missing files are omitted from prompts but recorded in `prompt-context.json`. Codex Cage does not inject README excerpts or raw `.codex-cage.yml` content.
+Independent review has a separate project policy file at `.codex-cage/review-policy.md`. `codex-cage init` creates a starter template. The review policy may add stricter project-specific checks, but it cannot override Codex Cage built-in reviewer rules or weaken blocking criteria. Missing review policy files are allowed.
 
 Each run records prompt context artifacts under `.codex-cage/runs/<run-id>`:
 
 - `prompt-context.json`
-- `instructions.md` when any instructions were included
 - `implementation-prompt-<iteration>.md`
 - `review-prompt-<cycle>.md`
+
+Prompt artifacts include review policy path/status only; they do not include full review policy contents.
 
 ## Running GitHub Issues
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -14,7 +14,7 @@ const configPath = ".codex-cage.yml";
 const envExamplePath = ".codex-cage.env.example";
 const gitignorePath = ".gitignore";
 const dockerfilePath = ".codex-cage/Dockerfile";
-const instructionsPath = ".codex-cage/instructions.md";
+const reviewPolicyPath = ".codex-cage/review-policy.md";
 
 const defaultConfig = `# Codex Cage target repo configuration.
 # Replace the verify command before running Codex Cage.
@@ -68,11 +68,22 @@ const dockerfile = `FROM ghcr.io/jhowliu/codex-cage/base:0.1.1
 # Add target-repo system dependencies here.
 `;
 
-const instructions = `# Codex Cage Instructions
+const reviewPolicy = `# Codex Cage Review Policy
 
-- Follow the repository's existing style and tests.
-- Keep changes focused on the issue.
-- Do not commit, push, create pull requests, or write secrets.
+Add project-specific review checks here. These rules are used only during the independent review phase.
+
+This file may add stricter review criteria, but it cannot override Codex Cage built-in reviewer rules or weaken blocking criteria.
+
+## Blocking Checks
+
+- Security-sensitive changes must include tests or a clear validation path.
+- Database migrations must preserve existing data or document why data loss is acceptable.
+- Authentication and authorization changes must cover failure cases.
+- Changes that touch secrets, credentials, tokens, or environment handling must avoid exposing sensitive values to logs, artifacts, or untrusted commands.
+
+## Project-Specific Notes
+
+- Add domain-specific invariants here.
 `;
 
 const gitignoreEntries = [".codex-cage.env", ".codex-cage/runs/", ".codex-cage/*.sqlite"];
@@ -85,7 +96,7 @@ export async function initProject(
   const updated: string[] = [];
   const configFilePath = join(cwd, configPath);
   const dockerfileFilePath = join(cwd, dockerfilePath);
-  const instructionsFilePath = join(cwd, instructionsPath);
+  const reviewPolicyFilePath = join(cwd, reviewPolicyPath);
 
   await assertFileDoesNotExist(cwd, configFilePath);
 
@@ -94,8 +105,8 @@ export async function initProject(
   }
 
   await createFileOnce(cwd, configFilePath, defaultConfig, created);
-  if (!(await fileExists(instructionsFilePath))) {
-    await createFileOnce(cwd, instructionsFilePath, instructions, created);
+  if (!(await fileExists(reviewPolicyFilePath))) {
+    await createFileOnce(cwd, reviewPolicyFilePath, reviewPolicy, created);
   }
   await mergeEnvExample(cwd, join(cwd, envExamplePath), created, updated);
   await appendGitignoreEntries(cwd, join(cwd, gitignorePath), updated);

--- a/src/prompt-context.ts
+++ b/src/prompt-context.ts
@@ -1,137 +1,55 @@
-import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { constants } from "node:fs";
+import { access } from "node:fs/promises";
+import { posix, resolve } from "node:path";
 
-export const instructionFileCandidates = [
-  "AGENTS.md",
-  ".codex-cage/instructions.md",
-  ".github/copilot-instructions.md",
-  "CLAUDE.md",
-] as const;
+export const reviewPolicyPath = ".codex-cage/review-policy.md";
+export const defaultPromptWorkspacePath = "/workspace";
 
-export const instructionPromptLimitBytes = 32 * 1024;
+export type ReviewPolicyStatus = "present" | "missing";
 
-export type InstructionFileStatus = "included" | "missing" | "truncated" | "skipped";
-
-export type InstructionFileResult = {
+export type ReviewPolicyResult = {
   path: string;
-  status: InstructionFileStatus;
-  bytes: number;
-  includedBytes: number;
+  containerPath: string;
+  status: ReviewPolicyStatus;
 };
 
 export type PromptContext = {
-  instructions: string;
-  instructionFiles: InstructionFileResult[];
-  limitBytes: number;
-  truncated: boolean;
+  reviewPolicy: ReviewPolicyResult;
 };
 
-export async function buildPromptContext(cwd: string): Promise<PromptContext> {
-  const instructionFiles: InstructionFileResult[] = [];
-  const sections: string[] = [];
-  let remainingBytes = instructionPromptLimitBytes;
-  let truncated = false;
-
-  for (const path of instructionFileCandidates) {
-    const content = await readOptionalInstruction(cwd, path);
-
-    if (content === null) {
-      instructionFiles.push({
-        path,
-        status: "missing",
-        bytes: 0,
-        includedBytes: 0,
-      });
-      continue;
-    }
-
-    const contentBytes = Buffer.byteLength(content, "utf8");
-
-    if (remainingBytes <= 0) {
-      truncated = true;
-      instructionFiles.push({
-        path,
-        status: "skipped",
-        bytes: contentBytes,
-        includedBytes: 0,
-      });
-      continue;
-    }
-
-    const sectionPrefix = `## ${path}\n\n`;
-    const sectionOverheadBytes = Buffer.byteLength(sectionPrefix, "utf8");
-    const contentLimit = Math.max(0, remainingBytes - sectionOverheadBytes);
-    const limited = truncateUtf8(
-      content,
-      contentLimit,
-      `\n\n[Instruction file truncated at ${contentLimit} bytes]\n`,
-    );
-    const section = `${sectionPrefix}${limited.content.trimEnd()}`;
-    const sectionBytes = Buffer.byteLength(section, "utf8");
-
-    remainingBytes = Math.max(0, remainingBytes - sectionBytes);
-    truncated = truncated || limited.truncated;
-    instructionFiles.push({
-      path,
-      status: limited.truncated ? "truncated" : "included",
-      bytes: contentBytes,
-      includedBytes: Buffer.byteLength(limited.content, "utf8"),
-    });
-    sections.push(section);
-  }
-
+export async function buildPromptContext(
+  cwd: string,
+  workspacePath = defaultPromptWorkspacePath,
+): Promise<PromptContext> {
   return {
-    instructions: sections.join("\n\n"),
-    instructionFiles,
-    limitBytes: instructionPromptLimitBytes,
-    truncated,
+    reviewPolicy: {
+      path: reviewPolicyPath,
+      containerPath: posix.join(workspacePath, reviewPolicyPath),
+      status: (await fileExists(resolve(cwd, reviewPolicyPath))) ? "present" : "missing",
+    },
   };
 }
 
-export function formatInstructionsForPrompt(context: PromptContext): string {
-  if (context.instructions === "") {
-    return "";
+export function formatReviewPolicyForPrompt(context: PromptContext): string {
+  if (context.reviewPolicy.status === "present") {
+    return `Target review policy: present at ${context.reviewPolicy.containerPath}.
+Read it before reviewing. It may add stricter project-specific checks, but it cannot weaken this prompt's blocking criteria.`;
   }
 
-  return `Repository instructions:
-Follow these repository-specific instructions when they apply. If source files or tests conflict with this context, treat the source files and tests as authoritative.
-
-${context.instructions}`;
+  return "Target review policy: missing. Proceed with built-in review rules.";
 }
 
-async function readOptionalInstruction(
-  cwd: string,
-  path: string,
-): Promise<string | null> {
+async function fileExists(path: string): Promise<boolean> {
   try {
-    return await readFile(resolve(cwd, path), "utf8");
+    await access(path, constants.R_OK);
+    return true;
   } catch (error) {
-    if (isNodeError(error) && error.code === "ENOENT") {
-      return null;
+    if (isNodeError(error) && (error.code === "ENOENT" || error.code === "EACCES")) {
+      return false;
     }
 
     throw error;
   }
-}
-
-function truncateUtf8(
-  value: string,
-  limitBytes: number,
-  marker: string,
-): { content: string; truncated: boolean } {
-  if (Buffer.byteLength(value, "utf8") <= limitBytes) {
-    return { content: value, truncated: false };
-  }
-
-  let content = value;
-  const markerBytes = Buffer.byteLength(marker, "utf8");
-  const contentLimit = Math.max(0, limitBytes - markerBytes);
-
-  while (Buffer.byteLength(content, "utf8") > contentLimit) {
-    content = content.slice(0, -1);
-  }
-
-  return { content: `${content}${marker}`, truncated: true };
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/src/review.ts
+++ b/src/review.ts
@@ -40,6 +40,7 @@ export type BuildReviewPromptInput = {
   issueContext: string;
   diff: string;
   verificationSummary: string;
+  reviewPolicyStatus?: string | undefined;
   resultMetadata: Record<string, unknown>;
 };
 
@@ -248,6 +249,9 @@ ${input.issueContext}
 
 Verification summary:
 ${input.verificationSummary}
+
+Review policy:
+${input.reviewPolicyStatus ?? "Target review policy: missing. Proceed with built-in review rules."}
 
 Result metadata:
 ${JSON.stringify(input.resultMetadata, null, 2)}

--- a/src/run.ts
+++ b/src/run.ts
@@ -35,7 +35,7 @@ import {
 } from "./publish.js";
 import {
   buildPromptContext,
-  formatInstructionsForPrompt,
+  formatReviewPolicyForPrompt,
   type PromptContext,
 } from "./prompt-context.js";
 import {
@@ -603,6 +603,7 @@ async function runImplementationLoop(input: {
         const reviewPrompt = buildReviewPrompt({
           issueContext: reviewIssueContext,
           verificationSummary: verification.summary,
+          reviewPolicyStatus: formatReviewPolicyForPrompt(input.context.promptContext),
           resultMetadata,
           diff,
         });
@@ -619,6 +620,7 @@ async function runImplementationLoop(input: {
           issueContext: reviewIssueContext,
           diff,
           verificationSummary: verification.summary,
+          reviewPolicyStatus: formatReviewPolicyForPrompt(input.context.promptContext),
           resultMetadata,
           readCurrentDiff: async () => await readCurrentDiff(input.shell),
           runner: reviewAgentRunner(input.shell),
@@ -937,13 +939,12 @@ Rules:
 - Work only in this repository.
 - Do not commit, push, create pull requests, or write secrets.
 - Run only commands needed to implement the issue; Codex Cage will run verification separately.
+- Follow applicable native Codex AGENTS.md files discovered in this repository.
 - If the issue lacks enough detail to implement safely, stop and explain the blocker.
 
 Iteration: ${input.iteration}
 Repository: ${input.context.repoResolution.repo.fullName}
 Base branch: ${input.context.baseBranch}
-
-${formatInstructionsForPrompt(input.context.promptContext)}
 
 Issue:
 ${formatIssueContext(input.context.issue)}
@@ -954,9 +955,7 @@ ${feedback}
 }
 
 function formatReviewIssueContext(context: RuntimeContext): string {
-  return `${formatInstructionsForPrompt(context.promptContext)}
-
-Issue:
+  return `Issue:
 ${formatIssueContext(context.issue)}`;
 }
 
@@ -1084,18 +1083,8 @@ async function writePromptContextArtifacts(
   context: RuntimeContext,
 ): Promise<void> {
   await writeJsonArtifact(store, context.runId, "prompt-context.json", {
-    instructionFiles: context.promptContext.instructionFiles,
-    limitBytes: context.promptContext.limitBytes,
-    truncated: context.promptContext.truncated,
+    reviewPolicy: context.promptContext.reviewPolicy,
   });
-
-  if (context.promptContext.instructions !== "") {
-    await store.writeArtifact(
-      context.runId,
-      "instructions.md",
-      context.promptContext.instructions,
-    );
-  }
 }
 
 async function writeFailureSummary(

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -17,7 +17,7 @@ test("init creates config, env example, and gitignore entries", async () => {
 
     assert.deepEqual(result.created, [
       ".codex-cage.yml",
-      ".codex-cage/instructions.md",
+      ".codex-cage/review-policy.md",
       ".codex-cage.env.example",
     ]);
     assert.deepEqual(result.updated, [".gitignore"]);
@@ -32,11 +32,12 @@ test("init creates config, env example, and gitignore entries", async () => {
     assert.match(envExample, /OPENAI_API_KEY=/);
     assert.match(envExample, /GITHUB_TOKEN=/);
 
-    const instructions = await readFile(
-      join(cwd, ".codex-cage", "instructions.md"),
+    const reviewPolicy = await readFile(
+      join(cwd, ".codex-cage", "review-policy.md"),
       "utf8",
     );
-    assert.match(instructions, /Do not commit, push, create pull requests/);
+    assert.match(reviewPolicy, /Codex Cage Review Policy/);
+    assert.match(reviewPolicy, /cannot override Codex Cage built-in reviewer rules/);
 
     const gitignore = await readFile(join(cwd, ".gitignore"), "utf8");
     assert.match(gitignore, /\.codex-cage\.env/);
@@ -46,7 +47,7 @@ test("init creates config, env example, and gitignore entries", async () => {
   }
 });
 
-test("init leaves existing instructions untouched", async () => {
+test("init ignores existing instructions and leaves existing review policy untouched", async () => {
   const cwd = await tempRepo();
 
   try {
@@ -56,15 +57,26 @@ test("init leaves existing instructions untouched", async () => {
       "custom instructions\n",
       "utf8",
     );
+    await writeFile(
+      join(cwd, ".codex-cage", "review-policy.md"),
+      "custom review policy\n",
+      "utf8",
+    );
 
     const result = await initProject(cwd);
     const instructions = await readFile(
       join(cwd, ".codex-cage", "instructions.md"),
       "utf8",
     );
+    const reviewPolicy = await readFile(
+      join(cwd, ".codex-cage", "review-policy.md"),
+      "utf8",
+    );
 
     assert.equal(result.created.includes(".codex-cage/instructions.md"), false);
+    assert.equal(result.created.includes(".codex-cage/review-policy.md"), false);
     assert.equal(instructions, "custom instructions\n");
+    assert.equal(reviewPolicy, "custom review policy\n");
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }

--- a/test/prompt-context.test.ts
+++ b/test/prompt-context.test.ts
@@ -5,65 +5,68 @@ import { join } from "node:path";
 import test from "node:test";
 import {
   buildPromptContext,
-  formatInstructionsForPrompt,
-  instructionPromptLimitBytes,
+  formatReviewPolicyForPrompt,
 } from "../src/prompt-context.js";
 
 async function tempProject(): Promise<string> {
   return await mkdtemp(join(tmpdir(), "codex-cage-prompt-context-"));
 }
 
-test("buildPromptContext reads root instruction files in priority order", async () => {
+test("buildPromptContext records present review policy without reading ignored instruction files", async () => {
   const cwd = await tempProject();
 
   try {
     await mkdir(join(cwd, ".codex-cage"), { recursive: true });
     await mkdir(join(cwd, ".github"), { recursive: true });
-    await writeFile(join(cwd, "AGENTS.md"), "Agent rules\n", "utf8");
-    await writeFile(join(cwd, ".codex-cage", "instructions.md"), "Cage rules\n", "utf8");
+    await writeFile(join(cwd, "AGENTS.md"), "Agent secret rule\n", "utf8");
     await writeFile(
-      join(cwd, ".github", "copilot-instructions.md"),
-      "Copilot rules\n",
+      join(cwd, ".codex-cage", "instructions.md"),
+      "Cage secret rule\n",
       "utf8",
     );
-    await writeFile(join(cwd, "CLAUDE.md"), "Claude rules\n", "utf8");
+    await writeFile(
+      join(cwd, ".codex-cage", "review-policy.md"),
+      "Policy secret content\n",
+      "utf8",
+    );
+    await writeFile(
+      join(cwd, ".github", "copilot-instructions.md"),
+      "Copilot secret rule\n",
+      "utf8",
+    );
+    await writeFile(join(cwd, "CLAUDE.md"), "Claude secret rule\n", "utf8");
 
     const context = await buildPromptContext(cwd);
+    const formatted = formatReviewPolicyForPrompt(context);
 
-    assert.deepEqual(
-      context.instructionFiles.map((file) => [file.path, file.status]),
-      [
-        ["AGENTS.md", "included"],
-        [".codex-cage/instructions.md", "included"],
-        [".github/copilot-instructions.md", "included"],
-        ["CLAUDE.md", "included"],
-      ],
-    );
-    assert.equal(
-      context.instructions.indexOf("## AGENTS.md") <
-        context.instructions.indexOf("## .codex-cage/instructions.md"),
-      true,
-    );
-    assert.match(formatInstructionsForPrompt(context), /Repository instructions:/);
+    assert.deepEqual(context.reviewPolicy, {
+      path: ".codex-cage/review-policy.md",
+      containerPath: "/workspace/.codex-cage/review-policy.md",
+      status: "present",
+    });
+    assert.match(formatted, /Target review policy: present/);
+    assert.match(formatted, /\/workspace\/\.codex-cage\/review-policy\.md/);
+    assert.doesNotMatch(JSON.stringify(context), /Agent secret rule/);
+    assert.doesNotMatch(JSON.stringify(context), /Cage secret rule/);
+    assert.doesNotMatch(JSON.stringify(context), /Copilot secret rule/);
+    assert.doesNotMatch(JSON.stringify(context), /Claude secret rule/);
+    assert.doesNotMatch(JSON.stringify(context), /Policy secret content/);
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }
 });
 
-test("buildPromptContext records missing files and truncates large instructions", async () => {
+test("buildPromptContext records missing review policy without failing", async () => {
   const cwd = await tempProject();
 
   try {
-    await writeFile(join(cwd, "AGENTS.md"), "a".repeat(40000), "utf8");
-
     const context = await buildPromptContext(cwd);
 
-    assert.equal(context.limitBytes, instructionPromptLimitBytes);
-    assert.equal(context.truncated, true);
-    assert.equal(context.instructionFiles[0]?.status, "truncated");
-    assert.equal(context.instructionFiles[1]?.status, "missing");
-    assert.match(context.instructions, /Instruction file truncated/);
-    assert.equal(Buffer.byteLength(context.instructions, "utf8") <= 32768, true);
+    assert.equal(context.reviewPolicy.status, "missing");
+    assert.equal(
+      formatReviewPolicyForPrompt(context),
+      "Target review policy: missing. Proceed with built-in review rules.",
+    );
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -48,6 +48,8 @@ test("buildReviewPrompt includes read-only instructions and required context", (
     issueContext: "Issue: add review",
     diff: "diff --git a/src/app.ts b/src/app.ts",
     verificationSummary: "npm test passed",
+    reviewPolicyStatus:
+      "Target review policy: present at /workspace/.codex-cage/review-policy.md.",
     resultMetadata: {
       runId: "run-1",
       verify: ["npm test"],
@@ -58,6 +60,7 @@ test("buildReviewPrompt includes read-only instructions and required context", (
   assert.match(prompt, /Do not edit files/);
   assert.match(prompt, /Issue: add review/);
   assert.match(prompt, /npm test passed/);
+  assert.match(prompt, /Target review policy: present/);
   assert.match(prompt, /"runId": "run-1"/);
   assert.match(prompt, /diff --git/);
 });

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -165,9 +165,17 @@ verify:
       join(cwd, ".codex-cage", "runs", "run-review-stdout", "review.log"),
       "utf8",
     );
+    const reviewPrompt = await readFile(
+      join(cwd, ".codex-cage", "runs", "run-review-stdout", "review-prompt-0.md"),
+      "utf8",
+    );
 
     assert.equal(result.status, "succeeded");
     assert.doesNotMatch(reviewLog, /^\$ printf/);
+    assert.match(
+      reviewPrompt,
+      /Target review policy: missing\. Proceed with built-in review rules\./,
+    );
     assert.deepEqual(JSON.parse(reviewLog), {
       decision: "pass",
       summary: "No blocking issues.",
@@ -183,7 +191,25 @@ test("runCodexCage executes the happy path and records a successful run", async 
 verify:
   - npm test
 `);
-  await writeFile(join(cwd, "AGENTS.md"), "Always write focused tests.\n", "utf8");
+  await mkdir(join(cwd, ".codex-cage"), { recursive: true });
+  await mkdir(join(cwd, ".github"), { recursive: true });
+  await writeFile(join(cwd, "AGENTS.md"), "Do not prompt-inject AGENTS.\n", "utf8");
+  await writeFile(
+    join(cwd, ".codex-cage", "instructions.md"),
+    "Do not prompt-inject cage instructions.\n",
+    "utf8",
+  );
+  await writeFile(
+    join(cwd, ".codex-cage", "review-policy.md"),
+    "Do not prompt-inject review policy contents.\n",
+    "utf8",
+  );
+  await writeFile(
+    join(cwd, ".github", "copilot-instructions.md"),
+    "Do not prompt-inject Copilot.\n",
+    "utf8",
+  );
+  await writeFile(join(cwd, "CLAUDE.md"), "Do not prompt-inject Claude.\n", "utf8");
   const events: string[] = [];
   const sandboxOptions: DockerSandboxOptions[] = [];
   const shell = shellRunner(
@@ -203,6 +229,7 @@ verify:
   );
   const published: PublishSuccessfulRunInput[] = [];
   let reviewIssueContext = "";
+  let reviewPolicyStatus = "";
 
   try {
     const result = await runCodexCage(
@@ -230,6 +257,7 @@ verify:
         createShellRunner: () => shell,
         runIndependentReview: async (input) => {
           reviewIssueContext = input.issueContext;
+          reviewPolicyStatus = input.reviewPolicyStatus ?? "";
           return passingReview();
         },
         publishSuccessfulRun: async (input) => {
@@ -274,20 +302,28 @@ verify:
       join(runDirectory, "prompt-context.json"),
       "utf8",
     );
-    const instructions = await readFile(join(runDirectory, "instructions.md"), "utf8");
 
     assert.equal(details.run.status, "succeeded");
     assert.equal(details.run.prUrl, "https://github.com/jhowliu/codex-cage/pull/26");
-    assert.match(implementationPrompt, /Repository instructions:/);
-    assert.match(implementationPrompt, /Always write focused tests/);
-    assert.match(reviewIssueContext, /Repository instructions:/);
+    assert.match(implementationPrompt, /native Codex AGENTS\.md/);
+    assert.doesNotMatch(implementationPrompt, /Do not prompt-inject/);
+    assert.doesNotMatch(reviewIssueContext, /Do not prompt-inject/);
     assert.match(reviewPrompt, /Verification summary:/);
+    assert.match(
+      reviewPrompt,
+      /Target review policy: present at \/workspace\/\.codex-cage\/review-policy\.md/,
+    );
+    assert.doesNotMatch(reviewPrompt, /Do not prompt-inject/);
+    assert.match(reviewPolicyStatus, /Target review policy: present/);
     assert.match(
       shell.commands.find((command) => command.includes("codex exec")) ?? "",
       /--sandbox 'workspace-write'/,
     );
-    assert.match(promptContext, /AGENTS\.md/);
-    assert.match(instructions, /Always write focused tests/);
+    assert.match(promptContext, /"status": "present"/);
+    assert.doesNotMatch(promptContext, /Do not prompt-inject/);
+    await assert.rejects(() => readFile(join(runDirectory, "instructions.md"), "utf8"), {
+      code: "ENOENT",
+    });
     assert.deepEqual(
       details.phases.map((phase) => phase.name),
       ["preflight", "cloning", "implement", "verify", "review", "pr"],


### PR DESCRIPTION
Closes #64

## Summary
- stop prompt-injecting repository instruction files and rely on native Codex AGENTS.md handling
- add review-policy status/path prompt context and init-created .codex-cage/review-policy.md
- update prompt artifacts, docs, and tests for the new behavior

## Validation
- npm run typecheck
- npm test
- npm run qa
- npm --cache /tmp/codex-cage-npm-cache pack --dry-run
- git diff --check
- npx prettier --check README.md docs/workflow.md src/init.ts src/prompt-context.ts src/review.ts src/run.ts test/init.test.ts test/prompt-context.test.ts test/review.test.ts test/run.test.ts

Note: repo-wide npm run format still fails on unrelated local .claude/settings.local.json.