### PR TITLE
#57 P2: Add no-publish dry-run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ codex-cage --help
 codex-cage init
 codex-cage init --dockerfile
 codex-cage run --issue <url>
+codex-cage run --no-publish --issue <url>
 codex-cage runs list
 codex-cage runs show <run-id>
 codex-cage cleanup
@@ -63,6 +64,8 @@ codex-cage run --issue https://github.com/OWNER/REPO/issues/123
 ```
 
 The `run` command reads `.codex-cage.yml` and `.codex-cage.env`, fetches issue context, resolves the target repo, creates a Docker workspace, starts configured Compose services, runs Codex implementation iterations, verifies configured commands, scans the diff for secrets, runs independent review, and publishes a PR when all gates pass.
+
+Use `--no-publish` or set `pr.publish: false` to stop after successful final patch and summary artifact generation without pushing a branch or creating a PR. The command reports that no PR was created and points to `.codex-cage/runs/<run-id>/final.patch`.
 
 ## Issue Context
 
@@ -139,6 +142,8 @@ Review is read-only. If the diff changes during review, the run fails instead of
 ## Publishing
 
 Successful runs are published by the orchestrator, not by the implementation or review agents. Codex Cage rejects empty diffs, creates a run-specific branch, configures the Codex Cage git author, commits once, pushes without force, and creates a ready GitHub PR by default.
+
+Publishing remains enabled by default. In no-publish mode, the run still rejects empty diffs and records `summary.md`, `final.patch`, and `pr.json` under the run artifact directory, but it does not perform remote writes.
 
 PR bodies include the summary, verification, review status, risks, run id, and issue linkage. GitHub issues use closing keywords such as `Closes #123`; Linear issues are linked without mutating Linear.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -100,6 +100,7 @@ timeouts:
   idle_minutes: 10
 
 pr:
+  publish: true
   draft: false
 
 git:
@@ -115,6 +116,8 @@ guards:
 ```
 
 `verify` must contain at least one command. The generated default intentionally fails until replaced with the target repo's real validation command.
+
+Set `pr.publish: false` or run `codex-cage run --no-publish ...` to stop after verification, guard scanning, independent review, and final artifact generation. Successful no-publish runs do not push a branch or create a PR; inspect `.codex-cage/runs/<run-id>/final.patch` and `summary.md` for the resulting patch and artifact locations.
 
 `runtime.image` accepts any valid Docker image reference and defaults to the Codex Cage GHCR base image. If `runtime.dockerfile` is set, Codex Cage builds a labeled per-run image before cloning the target repository. The first version uses `.codex-cage/` as the Docker build context, so target runtime Dockerfiles should keep package-install inputs inside that directory.
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { join } from "node:path";
 import { cleanupManagedDockerResources, type CleanupDockerReport } from "./docker.js";
 import { initProject } from "./init.js";
 import { runCodexCage, type RunProgressEvent } from "./run.js";
@@ -46,6 +47,7 @@ export function createCli(dependencies: CliDependencies = {}): Command {
     .option("--base <branch>", "base branch override")
     .option("--model <model>", "Codex model override")
     .option("--draft", "create a draft pull request")
+    .option("--no-publish", "stop after successful artifacts without creating a PR")
     .action(
       async (
         issueArgument: string | undefined,
@@ -55,6 +57,7 @@ export function createCli(dependencies: CliDependencies = {}): Command {
           base?: string;
           model?: string;
           draft?: boolean;
+          publish?: boolean;
         },
         command: Command,
       ) => {
@@ -73,6 +76,7 @@ export function createCli(dependencies: CliDependencies = {}): Command {
             base: options.base,
             model: options.model,
             draft: options.draft,
+            publish: options.publish === false ? false : undefined,
           }),
           {
             onProgress: (event) => {
@@ -94,6 +98,13 @@ export function createCli(dependencies: CliDependencies = {}): Command {
 
         if (result.prUrl !== null) {
           console.log(`${stdoutColor.label("PR")}: ${stdoutColor.link(result.prUrl)}`);
+        } else if (result.status === "succeeded") {
+          const artifactDir = join(process.cwd(), ".codex-cage", "runs", result.runId);
+          console.log(`${stdoutColor.label("PR")}: not created`);
+          console.log(`${stdoutColor.label("Artifacts")}: ${artifactDir}`);
+          console.log(
+            `${stdoutColor.label("Final patch")}: ${join(artifactDir, "final.patch")}`,
+          );
         }
       },
     );

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,9 +33,10 @@ export const codexCageConfigSchema = z
       .default(() => ({ total_minutes: 90, command_minutes: 20, idle_minutes: 10 })),
     pr: z
       .object({
+        publish: z.boolean().default(true),
         draft: z.boolean().default(false),
       })
-      .default(() => ({ draft: false })),
+      .default(() => ({ publish: true, draft: false })),
     git: z
       .object({
         base: z.string().default("main"),

--- a/src/init.ts
+++ b/src/init.ts
@@ -42,6 +42,7 @@ timeouts:
   idle_minutes: 10
 
 pr:
+  publish: true
   draft: false
 
 git:

--- a/src/run.ts
+++ b/src/run.ts
@@ -73,6 +73,7 @@ export type RunCommandOptions = {
   base?: string | undefined;
   model?: string | undefined;
   draft?: boolean | undefined;
+  publish?: boolean | undefined;
 };
 
 export type RunCodexCageResult = {
@@ -147,6 +148,7 @@ type RuntimeContext = {
   baseBranch: string;
   model: string;
   draft: boolean;
+  publish: boolean;
   runId: string;
   branchName: string;
   runtimeImage: RuntimeImageBuildResult & { source: "configured" | "built" };
@@ -417,6 +419,7 @@ async function prepareRuntimeContext(
   const baseBranch = options.base ?? configResult.config.git.base;
   const model = options.model ?? configResult.config.agent.model;
   const draft = options.draft ?? configResult.config.pr.draft;
+  const publish = options.publish ?? configResult.config.pr.publish;
   const runId = dependencies.generateRunId?.() ?? generateRunId();
   const branchName = generateBranchName({ issue, runId });
   const runtimeImage = {
@@ -440,6 +443,7 @@ async function prepareRuntimeContext(
     baseBranch,
     model,
     draft,
+    publish,
     runId,
     branchName,
     runtimeImage,
@@ -671,6 +675,45 @@ async function runImplementationLoop(input: {
       throw new RunFailureError("review_blocking", reviewResult.nextAction.feedback);
     }
 
+    const finalPatch = await readCurrentDiff(input.shell);
+
+    if (finalPatch.trim() === "") {
+      throw new NoDiffError();
+    }
+
+    await input.store.writeArtifact(input.context.runId, "final.patch", finalPatch);
+
+    if (!input.context.publish) {
+      await writeJsonArtifact(input.store, input.context.runId, "pr.json", {
+        created: false,
+        reason: "publish disabled",
+      });
+      await input.store.writeArtifact(
+        input.context.runId,
+        "summary.md",
+        [
+          `# ${input.context.runId}`,
+          "",
+          "PR: not created (publish disabled)",
+          `Final patch: ${input.store.artifactPath(input.context.runId, "final.patch")}`,
+          `Artifacts: ${input.store.runDirectory(input.context.runId)}`,
+          "",
+        ].join("\n"),
+      );
+      await input.store.updateRunStatus(input.context.runId, {
+        status: "succeeded",
+        prUrl: null,
+        finishedAt: new Date(),
+      });
+
+      return {
+        runId: input.context.runId,
+        status: "succeeded",
+        failureCode: null,
+        prUrl: null,
+      };
+    }
+
     await input.store.updateRunStatus(input.context.runId, { status: "creating_pr" });
     const publishResult = await runPhase(
       input.store,
@@ -724,11 +767,6 @@ async function runImplementationLoop(input: {
     );
 
     await writeJsonArtifact(input.store, input.context.runId, "pr.json", publishResult);
-    await input.store.writeArtifact(
-      input.context.runId,
-      "final.patch",
-      await readCurrentDiff(input.shell),
-    );
     await input.store.writeArtifact(
       input.context.runId,
       "summary.md",

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -130,6 +130,42 @@ test("run keeps the --issue option for compatibility", async () => {
   ]);
 });
 
+test("run accepts --no-publish", async () => {
+  const calls: RunCommandOptions[] = [];
+  const originalConsoleLog = console.log;
+  const program = createCli({
+    runCodexCage: async (input): Promise<RunCodexCageResult> => {
+      calls.push(input);
+      return {
+        runId: "run-cli-test",
+        status: "succeeded",
+        failureCode: null,
+        prUrl: null,
+      };
+    },
+  });
+
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => undefined, writeErr: () => undefined });
+  console.log = () => undefined;
+
+  try {
+    await program.parseAsync(
+      ["run", "--no-publish", "https://github.com/jhowliu/codex-cage/issues/35"],
+      { from: "user" },
+    );
+  } finally {
+    console.log = originalConsoleLog;
+  }
+
+  assert.deepEqual(calls, [
+    {
+      issueUrl: "https://github.com/jhowliu/codex-cage/issues/35",
+      publish: false,
+    },
+  ]);
+});
+
 test("runs list and show read local run metadata", async () => {
   const cwd = await mkdtemp(join(tmpdir(), "codex-cage-cli-runs-"));
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -11,12 +11,25 @@ test("config schema accepts a minimal valid config", () => {
   assert.deepEqual(config.setup, []);
   assert.deepEqual(config.verify, ["npm test"]);
   assert.equal(config.git.base, "main");
+  assert.equal(config.pr.publish, true);
   assert.equal(config.pr.draft, false);
   assert.equal(config.issue.comments, 10);
   assert.deepEqual(config.runtime, {
     image: defaultSandboxImage,
     dockerfile: null,
   });
+});
+
+test("config schema supports disabling publish", () => {
+  const config = codexCageConfigSchema.parse({
+    verify: ["npm test"],
+    pr: {
+      publish: false,
+    },
+  });
+
+  assert.equal(config.pr.publish, false);
+  assert.equal(config.pr.draft, false);
 });
 
 test("config schema rejects empty verify commands", () => {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -405,6 +405,85 @@ verify:
   }
 });
 
+test("runCodexCage skips publishing in no-publish mode and keeps final artifacts", async () => {
+  const cwd = await createProject(`
+verify:
+  - npm test
+`);
+  const events: string[] = [];
+  const diff = `diff --git a/src/app.ts b/src/app.ts
+@@ -1 +1,2 @@
+ export const ok = true;
++export const changed = true;
+`;
+  const shell = shellRunner(
+    new Map([
+      ["git fetch origin", commandResult()],
+      ["codex exec", commandResult("implemented")],
+      ["npm test", commandResult("tests passed")],
+      ["git add --intent-to-add", commandResult(diff)],
+    ]),
+  );
+
+  try {
+    const result = await runCodexCage(
+      {
+        cwd,
+        issueUrl: issue.url,
+        publish: false,
+      },
+      {
+        generateRunId: () => "run-no-publish",
+        readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
+        findCodexAuthFile: async () => null,
+        fetchIssueContext: async () => issue,
+        resolveTargetRepo: async () => repoResolution,
+        createAuthenticatedRepo: () => ({
+          repo,
+          cloneUrl:
+            "https://x-access-token:token-value@github.com/jhowliu/codex-cage.git",
+          redactedCloneUrl:
+            "https://x-access-token:[REDACTED]@github.com/jhowliu/codex-cage.git",
+        }),
+        createDockerSandbox: () => fakeSandbox(events),
+        createShellRunner: () => shell,
+        runIndependentReview: async () => passingReview(),
+        publishSuccessfulRun: async () => {
+          throw new Error("publish should not be called in no-publish mode");
+        },
+      },
+    );
+
+    assert.deepEqual(result, {
+      runId: "run-no-publish",
+      status: "succeeded",
+      failureCode: null,
+      prUrl: null,
+    });
+
+    const runDirectory = join(cwd, ".codex-cage", "runs", "run-no-publish");
+    const finalPatch = await readFile(join(runDirectory, "final.patch"), "utf8");
+    const summary = await readFile(join(runDirectory, "summary.md"), "utf8");
+    const pr = JSON.parse(await readFile(join(runDirectory, "pr.json"), "utf8"));
+    const store = await openRunStore(cwd);
+    const details = store.getRunDetails("run-no-publish");
+    store.close();
+
+    assert.equal(finalPatch, diff);
+    assert.match(summary, /PR: not created \(publish disabled\)/);
+    assert.match(summary, /Final patch:/);
+    assert.deepEqual(pr, { created: false, reason: "publish disabled" });
+    assert.equal(details.run.status, "succeeded");
+    assert.equal(details.run.prUrl, null);
+    assert.deepEqual(
+      details.phases.map((phase) => phase.name),
+      ["preflight", "cloning", "implement", "verify", "review"],
+    );
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
 test("runCodexCage builds configured runtime Dockerfiles before cloning", async () => {
   const cwd = await createProject(`
 verify:


### PR DESCRIPTION
## Summary
Implemented #57: P2: Add no-publish dry-run mode

## Verification
- `npm run test` passed

## Review
Independent review passed.

## Risks
- None noted.

## Run
- Run ID: run-20260426023700-po8wxz

## Issue
- https://github.com/jhowliu/codex-cage/issues/57
- Closes #57
