### PR TITLE
#57 P2: Add no-publish dry-run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Run a GitHub issue:
 codex-cage run https://github.com/OWNER/REPO/issues/123
 ```
 
+Inspect a successful run without remote writes:
+
+```bash
+codex-cage run https://github.com/OWNER/REPO/issues/123 --no-publish
+```
+
 Run a Linear issue by passing the target GitHub repo:
 
 ```bash
@@ -90,6 +96,7 @@ Use `codex-cage --help` or `codex-cage <command> --help` for the current CLI hel
 | `codex-cage init --dockerfile`       | Also create `.codex-cage/Dockerfile` for target repos that need custom system packages. |
 | `codex-cage run <issue-url>`         | Run the full issue-to-PR workflow for a GitHub or Linear issue.                         |
 | `codex-cage run --issue <issue-url>` | Alternate issue URL form kept for compatibility.                                        |
+| `codex-cage run --no-publish`        | Stop after final artifacts without pushing a branch or creating a PR.                   |
 | `codex-cage runs list`               | List locally recorded runs from `.codex-cage/codex-cage.sqlite`.                        |
 | `codex-cage runs show <run-id>`      | Show run metadata, phase status, and artifact paths.                                    |
 | `codex-cage cleanup`                 | Remove stale stopped Docker resources managed by Codex Cage.                            |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -101,6 +101,7 @@ timeouts:
 
 pr:
   draft: false
+  publish: true
 
 git:
   base: main
@@ -115,6 +116,8 @@ guards:
 ```
 
 `verify` must contain at least one command. The generated default intentionally fails until replaced with the target repo's real validation command.
+
+Set `pr.publish: false` or pass `codex-cage run --no-publish` to stop after verification, guards, review, and final artifact generation without pushing a branch or creating a PR. Successful no-publish runs write `final.patch`, `summary.md`, and `pr.json` under the run artifact directory.
 
 `runtime.image` accepts any valid Docker image reference and defaults to the Codex Cage GHCR base image. If `runtime.dockerfile` is set, Codex Cage builds a labeled per-run image before cloning the target repository. The first version uses `.codex-cage/` as the Docker build context, so target runtime Dockerfiles should keep package-install inputs inside that directory.
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -46,6 +46,10 @@ export function createCli(dependencies: CliDependencies = {}): Command {
     .option("--base <branch>", "base branch override")
     .option("--model <model>", "Codex model override")
     .option("--draft", "create a draft pull request")
+    .option(
+      "--no-publish",
+      "stop after final artifacts without pushing a branch or creating a PR",
+    )
     .action(
       async (
         issueArgument: string | undefined,
@@ -55,12 +59,14 @@ export function createCli(dependencies: CliDependencies = {}): Command {
           base?: string;
           model?: string;
           draft?: boolean;
+          publish?: boolean;
         },
         command: Command,
       ) => {
         const issueUrl = options.issue ?? issueArgument;
         const stdoutColor = createColorizer(process.stdout);
         const stderrColor = createColorizer(process.stderr);
+        let artifactDir: string | null = null;
 
         if (issueUrl === undefined) {
           command.error("error: missing required issue URL");
@@ -73,9 +79,13 @@ export function createCli(dependencies: CliDependencies = {}): Command {
             base: options.base,
             model: options.model,
             draft: options.draft,
+            publish: options.publish === false ? false : undefined,
           }),
           {
             onProgress: (event) => {
+              if (event.type === "run_started") {
+                artifactDir = event.artifactDir;
+              }
               console.error(formatRunProgressEvent(event, stderrColor));
             },
           },
@@ -94,6 +104,18 @@ export function createCli(dependencies: CliDependencies = {}): Command {
 
         if (result.prUrl !== null) {
           console.log(`${stdoutColor.label("PR")}: ${stdoutColor.link(result.prUrl)}`);
+        } else if (result.status === "succeeded") {
+          console.log(`${stdoutColor.label("PR")}: ${stdoutColor.muted("not created")}`);
+          if (artifactDir !== null) {
+            console.log(
+              `${stdoutColor.label("Artifacts")}: ${stdoutColor.info(artifactDir)}`,
+            );
+            console.log(
+              `${stdoutColor.label("Final patch")}: ${stdoutColor.info(
+                `${artifactDir}/final.patch`,
+              )}`,
+            );
+          }
         }
       },
     );
@@ -219,11 +241,17 @@ function formatRunProgressEvent(
       return `${color.success(`[${event.phase}] passed`)} (${event.logPath})`;
     case "phase_failed":
       return `${color.failure(`[${event.phase}] failed`)} (${event.logPath})`;
+    case "phase_skipped":
+      return `${color.warning(`[${event.phase}] skipped`)} (${event.logPath})`;
     case "run_finished":
       return event.status === "succeeded"
         ? `${color.heading("Run")} ${color.info(event.runId)} ${color.success(
             "succeeded",
-          )}${event.prUrl === null ? "" : `: ${color.link(event.prUrl)}`}`
+          )}${
+            event.prUrl === null
+              ? `: ${color.muted("no PR created")}`
+              : `: ${color.link(event.prUrl)}`
+          }`
         : `${color.heading("Run")} ${color.info(event.runId)} ${color.failure(
             "failed",
           )}: ${color.failure(event.failureCode ?? "unknown")}`;

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,8 +34,9 @@ export const codexCageConfigSchema = z
     pr: z
       .object({
         draft: z.boolean().default(false),
+        publish: z.boolean().default(true),
       })
-      .default(() => ({ draft: false })),
+      .default(() => ({ draft: false, publish: true })),
     git: z
       .object({
         base: z.string().default("main"),

--- a/src/init.ts
+++ b/src/init.ts
@@ -43,6 +43,7 @@ timeouts:
 
 pr:
   draft: false
+  publish: true
 
 git:
   base: main

--- a/src/run.ts
+++ b/src/run.ts
@@ -41,6 +41,7 @@ import {
   type CommandResult,
   type CommandRunOptions,
   type CommandRunner,
+  type PublishSuccessfulRunResult,
 } from "./publish.js";
 import {
   buildPromptContext,
@@ -74,6 +75,7 @@ export type RunCommandOptions = {
   base?: string | undefined;
   model?: string | undefined;
   draft?: boolean | undefined;
+  publish?: boolean | undefined;
 };
 
 export type RunCodexCageResult = {
@@ -94,7 +96,7 @@ export type RunProgressEvent =
       artifactDir: string;
     }
   | {
-      type: "phase_started" | "phase_passed" | "phase_failed";
+      type: "phase_started" | "phase_passed" | "phase_failed" | "phase_skipped";
       runId: string;
       phase: PhaseName;
       logPath: string;
@@ -148,6 +150,7 @@ type RuntimeContext = {
   baseBranch: string;
   model: string;
   draft: boolean;
+  publish: boolean;
   runId: string;
   branchName: string;
   runtimeImage: RuntimeImageBuildResult & { source: "configured" | "built" };
@@ -418,6 +421,7 @@ async function prepareRuntimeContext(
   const baseBranch = options.base ?? configResult.config.git.base;
   const model = options.model ?? configResult.config.agent.model;
   const draft = options.draft ?? configResult.config.pr.draft;
+  const publish = options.publish ?? configResult.config.pr.publish;
   const runId = dependencies.generateRunId?.() ?? generateRunId();
   const branchName = generateBranchName({ issue, runId });
   const runtimeImage = {
@@ -441,6 +445,7 @@ async function prepareRuntimeContext(
     baseBranch,
     model,
     draft,
+    publish,
     runId,
     branchName,
     runtimeImage,
@@ -672,66 +677,94 @@ async function runImplementationLoop(input: {
       throw new RunFailureError("review_blocking", reviewResult.nextAction.feedback);
     }
 
-    await input.store.updateRunStatus(input.context.runId, { status: "creating_pr" });
-    const publishResult = await runPhase(
-      input.store,
-      input.context.runId,
-      "pr",
-      input.onProgress,
-      async () => {
-        let result;
-        const publishCredentials = runtimeCommandCredentials("publish", input.context);
+    const finalPatch = await readCurrentDiff(input.shell);
+    if (finalPatch.trim() === "") {
+      throw new NoDiffError();
+    }
 
-        try {
-          result = await input.publish({
-            cwd: input.context.cwd,
-            repo: input.context.repoResolution.repo,
-            issue: input.context.issue,
-            baseBranch: input.context.baseBranch,
-            authorName: input.context.config.git.author_name,
-            authorEmail: input.context.config.git.author_email,
-            branchName: input.context.branchName,
-            draft: input.context.draft,
-            env: publishCredentials.env,
-            metadata: {
-              runId: input.context.runId,
-              summary: `Implemented ${input.context.issue.identifier}: ${input.context.issue.title}`,
-              verification: verification.items,
-              reviewStatus: "Independent review passed.",
-              risks: [],
-            },
-            git: shellCommandRunner(input.shell, "git", publishCredentials),
-            gh: shellCommandRunner(input.shell, "gh", publishCredentials),
-          });
-        } catch (error) {
-          if (error instanceof NoDiffError) {
-            throw error;
+    let publishResult: PublishSuccessfulRunResult | null = null;
+
+    if (input.context.publish) {
+      await input.store.updateRunStatus(input.context.runId, { status: "creating_pr" });
+      publishResult = await runPhase(
+        input.store,
+        input.context.runId,
+        "pr",
+        input.onProgress,
+        async () => {
+          let result;
+          const publishCredentials = runtimeCommandCredentials("publish", input.context);
+
+          try {
+            result = await input.publish({
+              cwd: input.context.cwd,
+              repo: input.context.repoResolution.repo,
+              issue: input.context.issue,
+              baseBranch: input.context.baseBranch,
+              authorName: input.context.config.git.author_name,
+              authorEmail: input.context.config.git.author_email,
+              branchName: input.context.branchName,
+              draft: input.context.draft,
+              env: publishCredentials.env,
+              metadata: {
+                runId: input.context.runId,
+                summary: `Implemented ${input.context.issue.identifier}: ${input.context.issue.title}`,
+                verification: verification.items,
+                reviewStatus: "Independent review passed.",
+                risks: [],
+              },
+              git: shellCommandRunner(input.shell, "git", publishCredentials),
+              gh: shellCommandRunner(input.shell, "gh", publishCredentials),
+            });
+          } catch (error) {
+            if (error instanceof NoDiffError) {
+              throw error;
+            }
+
+            throw new RunFailureError("pr_failed", input.redactor(formatError(error)));
           }
 
-          throw new RunFailureError("pr_failed", input.redactor(formatError(error)));
-        }
+          return {
+            log: input.redactor(JSON.stringify(result, null, 2)),
+            value: result,
+          };
+        },
+      );
+    } else {
+      await skipPhase(
+        input.store,
+        input.context.runId,
+        "pr",
+        input.onProgress,
+        "Publish disabled. No branch was pushed and no PR was created.",
+      );
+    }
 
-        return {
-          log: input.redactor(JSON.stringify(result, null, 2)),
-          value: result,
-        };
+    await writeJsonArtifact(
+      input.store,
+      input.context.runId,
+      "pr.json",
+      publishResult ?? {
+        published: false,
+        branchName: input.context.branchName,
+        prUrl: null,
+        reason: "publish_disabled",
       },
     );
-
-    await writeJsonArtifact(input.store, input.context.runId, "pr.json", publishResult);
-    await input.store.writeArtifact(
-      input.context.runId,
-      "final.patch",
-      await readCurrentDiff(input.shell),
-    );
+    await input.store.writeArtifact(input.context.runId, "final.patch", finalPatch);
     await input.store.writeArtifact(
       input.context.runId,
       "summary.md",
-      `# ${input.context.runId}\n\nPR: ${publishResult.prUrl}\n`,
+      publishResult === null
+        ? `# ${input.context.runId}\n\nPR: not created (publish disabled)\n\nFinal patch: ${input.store.artifactPath(
+            input.context.runId,
+            "final.patch",
+          )}\n`
+        : `# ${input.context.runId}\n\nPR: ${publishResult.prUrl}\n`,
     );
     await input.store.updateRunStatus(input.context.runId, {
       status: "succeeded",
-      prUrl: publishResult.prUrl,
+      prUrl: publishResult?.prUrl ?? null,
       finishedAt: new Date(),
     });
 
@@ -739,7 +772,7 @@ async function runImplementationLoop(input: {
       runId: input.context.runId,
       status: "succeeded",
       failureCode: null,
-      prUrl: publishResult.prUrl,
+      prUrl: publishResult?.prUrl ?? null,
     };
   }
 
@@ -845,6 +878,21 @@ async function runPhase<TValue = undefined>(
     onProgress({ type: "phase_failed", runId, phase: name, logPath });
     throw error;
   }
+}
+
+async function skipPhase(
+  store: RunStore,
+  runId: string,
+  name: PhaseName,
+  onProgress: (event: RunProgressEvent) => void,
+  log: string,
+): Promise<void> {
+  const logPath = store.artifactPath(runId, `${name}.log`);
+  onProgress({ type: "phase_started", runId, phase: name, logPath });
+  const phase = await store.startPhase({ runId, name, logPath });
+  await store.writeArtifact(runId, `${name}.log`, log);
+  await store.finishPhase({ phaseId: phase.id, status: "skipped", logPath });
+  onProgress({ type: "phase_skipped", runId, phase: name, logPath });
 }
 
 function createDockerShellRunner(

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -130,6 +130,85 @@ test("run keeps the --issue option for compatibility", async () => {
   ]);
 });
 
+test("run accepts --no-publish", async () => {
+  const calls: RunCommandOptions[] = [];
+  const originalConsoleLog = console.log;
+  const program = createCli({
+    runCodexCage: async (input): Promise<RunCodexCageResult> => {
+      calls.push(input);
+      return {
+        runId: "run-cli-test",
+        status: "succeeded",
+        failureCode: null,
+        prUrl: null,
+      };
+    },
+  });
+
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => undefined, writeErr: () => undefined });
+  console.log = () => undefined;
+
+  try {
+    await program.parseAsync(
+      ["run", "https://github.com/jhowliu/codex-cage/issues/35", "--no-publish"],
+      { from: "user" },
+    );
+  } finally {
+    console.log = originalConsoleLog;
+  }
+
+  assert.deepEqual(calls, [
+    {
+      issueUrl: "https://github.com/jhowliu/codex-cage/issues/35",
+      publish: false,
+    },
+  ]);
+});
+
+test("run reports a successful no-publish run without a PR", async () => {
+  const originalConsoleLog = console.log;
+  const output: string[] = [];
+  const program = createCli({
+    runCodexCage: async (_input, dependencies): Promise<RunCodexCageResult> => {
+      dependencies?.onProgress?.({
+        type: "run_started",
+        runId: "run-cli-test",
+        issueKey: "#35",
+        issueTitle: "No publish",
+        repo: "jhowliu/codex-cage",
+        branch: "codex-cage/gh-35-run-cli-test",
+        artifactDir: "/tmp/codex-cage/runs/run-cli-test",
+      });
+      return {
+        runId: "run-cli-test",
+        status: "succeeded",
+        failureCode: null,
+        prUrl: null,
+      };
+    },
+  });
+
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => undefined, writeErr: () => undefined });
+  console.log = (value?: unknown) => {
+    output.push(String(value));
+  };
+
+  try {
+    await program.parseAsync(
+      ["run", "https://github.com/jhowliu/codex-cage/issues/35", "--no-publish"],
+      { from: "user" },
+    );
+  } finally {
+    console.log = originalConsoleLog;
+  }
+
+  assert.match(output.join("\n"), /PR: not created/);
+  assert.match(output.join("\n"), /Artifacts: \/tmp\/codex-cage\/runs\/run-cli-test/);
+  assert.match(output.join("\n"), /Final patch: .*final\.patch/);
+});
+
 test("runs list and show read local run metadata", async () => {
   const cwd = await mkdtemp(join(tmpdir(), "codex-cage-cli-runs-"));
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -12,11 +12,24 @@ test("config schema accepts a minimal valid config", () => {
   assert.deepEqual(config.verify, ["npm test"]);
   assert.equal(config.git.base, "main");
   assert.equal(config.pr.draft, false);
+  assert.equal(config.pr.publish, true);
   assert.equal(config.issue.comments, 10);
   assert.deepEqual(config.runtime, {
     image: defaultSandboxImage,
     dockerfile: null,
   });
+});
+
+test("config schema supports disabling PR publishing", () => {
+  const config = codexCageConfigSchema.parse({
+    verify: ["npm test"],
+    pr: {
+      publish: false,
+    },
+  });
+
+  assert.equal(config.pr.draft, false);
+  assert.equal(config.pr.publish, false);
 });
 
 test("config schema rejects empty verify commands", () => {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -473,6 +473,170 @@ verify:
   }
 });
 
+test("runCodexCage skips publish in no-publish mode and keeps final artifacts", async () => {
+  const cwd = await createProject(`
+verify:
+  - npm test
+pr:
+  publish: false
+`);
+  const events: string[] = [];
+  const diff = `diff --git a/src/app.ts b/src/app.ts
+@@ -1 +1,2 @@
+ export const ok = true;
++export const changed = true;
+`;
+  const shell = shellRunner(
+    new Map([
+      ["git fetch origin", commandResult()],
+      ["codex exec", commandResult("implemented")],
+      ["npm test", commandResult("tests passed")],
+      ["git add --intent-to-add", commandResult(diff)],
+    ]),
+  );
+
+  try {
+    const result = await runCodexCage(
+      {
+        cwd,
+        issueUrl: issue.url,
+      },
+      {
+        generateRunId: () => "run-no-publish",
+        readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
+        findCodexAuthFile: async () => null,
+        fetchIssueContext: async () => issue,
+        resolveTargetRepo: async () => repoResolution,
+        createAuthenticatedRepo: () => ({
+          repo,
+          cloneUrl: "https://github.com/jhowliu/codex-cage.git",
+          redactedCloneUrl: "https://github.com/jhowliu/codex-cage.git",
+        }),
+        createDockerSandbox: () => fakeSandbox(events),
+        createShellRunner: () => shell,
+        runIndependentReview: async () => passingReview(),
+        publishSuccessfulRun: async () => {
+          throw new Error("publish should not be called in no-publish mode");
+        },
+      },
+    );
+
+    const runDirectory = join(cwd, ".codex-cage", "runs", "run-no-publish");
+    const finalPatch = await readFile(join(runDirectory, "final.patch"), "utf8");
+    const summary = await readFile(join(runDirectory, "summary.md"), "utf8");
+    const pr = JSON.parse(await readFile(join(runDirectory, "pr.json"), "utf8")) as {
+      branchName: string;
+      published: boolean;
+      prUrl: string | null;
+      reason: string;
+    };
+    const prLog = await readFile(join(runDirectory, "pr.log"), "utf8");
+
+    assert.deepEqual(result, {
+      runId: "run-no-publish",
+      status: "succeeded",
+      failureCode: null,
+      prUrl: null,
+    });
+    assert.equal(finalPatch, diff);
+    assert.match(summary, /PR: not created \(publish disabled\)/);
+    assert.match(summary, /Final patch: .*final\.patch/);
+    assert.deepEqual(pr, {
+      published: false,
+      branchName: "codex-cage/gh-26-run-no-publish",
+      prUrl: null,
+      reason: "publish_disabled",
+    });
+    assert.match(prLog, /No branch was pushed and no PR was created/);
+
+    const store = await openRunStore(cwd);
+    const details = store.getRunDetails("run-no-publish");
+    store.close();
+
+    assert.equal(details.run.status, "succeeded");
+    assert.equal(details.run.prUrl, null);
+    assert.deepEqual(
+      details.phases.map((phase) => [phase.name, phase.status]),
+      [
+        ["preflight", "passed"],
+        ["cloning", "passed"],
+        ["implement", "passed"],
+        ["verify", "passed"],
+        ["review", "passed"],
+        ["pr", "skipped"],
+      ],
+    );
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("runCodexCage lets the CLI override config no-publish mode", async () => {
+  const cwd = await createProject(`
+verify:
+  - npm test
+pr:
+  publish: false
+`);
+  const events: string[] = [];
+  const shell = shellRunner(
+    new Map([
+      ["git fetch origin", commandResult()],
+      ["codex exec", commandResult("implemented")],
+      ["npm test", commandResult("tests passed")],
+      [
+        "git add --intent-to-add",
+        commandResult(`diff --git a/src/app.ts b/src/app.ts
+@@ -1 +1,2 @@
+ export const ok = true;
++export const changed = true;
+`),
+      ],
+    ]),
+  );
+  const published: PublishSuccessfulRunInput[] = [];
+
+  try {
+    const result = await runCodexCage(
+      {
+        cwd,
+        issueUrl: issue.url,
+        publish: true,
+      },
+      {
+        generateRunId: () => "run-publish-override",
+        readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
+        findCodexAuthFile: async () => null,
+        fetchIssueContext: async () => issue,
+        resolveTargetRepo: async () => repoResolution,
+        createAuthenticatedRepo: () => ({
+          repo,
+          cloneUrl: "https://github.com/jhowliu/codex-cage.git",
+          redactedCloneUrl: "https://github.com/jhowliu/codex-cage.git",
+        }),
+        createDockerSandbox: () => fakeSandbox(events),
+        createShellRunner: () => shell,
+        runIndependentReview: async () => passingReview(),
+        publishSuccessfulRun: async (input) => {
+          published.push(input);
+          return {
+            branchName: input.branchName ?? "codex-cage/gh-26-run-test",
+            commitMessage: "#26 Wire run command",
+            prTitle: "#26 Wire run command",
+            prBody: "body",
+            prUrl: "https://github.com/jhowliu/codex-cage/pull/26",
+          };
+        },
+      },
+    );
+
+    assert.equal(result.prUrl, "https://github.com/jhowliu/codex-cage/pull/26");
+    assert.equal(published.length, 1);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
 test("runCodexCage builds configured runtime Dockerfiles before cloning", async () => {
   const cwd = await createProject(`
 verify:


### PR DESCRIPTION
## Summary
Implemented #57: P2: Add no-publish dry-run mode

## Verification
- `npm run test` passed

## Review
Independent review passed.

## Risks
- None noted.

## Run
- Run ID: run-20260427131921-xfbxy5

## Issue
- https://github.com/jhowliu/codex-cage/issues/57
- Closes #57
