### PR TITLE
Clean up run workflow dependency wiring

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -73,31 +73,50 @@ export async function runCodexCage(
     return await runWorkflow({
       context,
       store,
-      ...(dependencies.createDockerSandbox === undefined
-        ? {}
-        : { createDockerSandbox: dependencies.createDockerSandbox }),
-      ...(dependencies.buildRuntimeImage === undefined
-        ? {}
-        : { buildRuntimeImage: dependencies.buildRuntimeImage }),
-      ...(dependencies.createShellRunner === undefined
-        ? {}
-        : { createShellRunner: dependencies.createShellRunner }),
-      ...(dependencies.createComposeProject === undefined
-        ? {}
-        : { createComposeProject: dependencies.createComposeProject }),
-      ...(dependencies.runIndependentReview === undefined
-        ? {}
-        : { runIndependentReview: dependencies.runIndependentReview }),
-      ...(dependencies.publishSuccessfulRun === undefined
-        ? {}
-        : { publishSuccessfulRun: dependencies.publishSuccessfulRun }),
-      ...(dependencies.onProgress === undefined
-        ? {}
-        : { onProgress: dependencies.onProgress }),
+      ...runWorkflowOverridesFromDependencies(dependencies),
     });
   } finally {
     store.close();
   }
+}
+
+function runWorkflowOverridesFromDependencies(
+  dependencies: RunCodexCageDependencies,
+): Partial<
+  Pick<
+    Parameters<typeof runWorkflow>[0],
+    | "createDockerSandbox"
+    | "buildRuntimeImage"
+    | "createShellRunner"
+    | "createComposeProject"
+    | "runIndependentReview"
+    | "publishSuccessfulRun"
+    | "onProgress"
+  >
+> {
+  return {
+    ...(dependencies.createDockerSandbox === undefined
+      ? {}
+      : { createDockerSandbox: dependencies.createDockerSandbox }),
+    ...(dependencies.buildRuntimeImage === undefined
+      ? {}
+      : { buildRuntimeImage: dependencies.buildRuntimeImage }),
+    ...(dependencies.createShellRunner === undefined
+      ? {}
+      : { createShellRunner: dependencies.createShellRunner }),
+    ...(dependencies.createComposeProject === undefined
+      ? {}
+      : { createComposeProject: dependencies.createComposeProject }),
+    ...(dependencies.runIndependentReview === undefined
+      ? {}
+      : { runIndependentReview: dependencies.runIndependentReview }),
+    ...(dependencies.publishSuccessfulRun === undefined
+      ? {}
+      : { publishSuccessfulRun: dependencies.publishSuccessfulRun }),
+    ...(dependencies.onProgress === undefined
+      ? {}
+      : { onProgress: dependencies.onProgress }),
+  };
 }
 
 async function prepareRuntimeContext(


### PR DESCRIPTION
## Summary

- Move optional run workflow dependency override wiring into a focused helper.
- Keep exact optional property handling centralized so runCodexCage reads as context prep plus workflow execution.
- No behavior changes.

## Validation

- npm run typecheck
- npm test
- npx prettier --check src/run.ts
- git diff --check