### PR TITLE
feat: add host ShellRunner and execution-mode selector

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -156,6 +156,27 @@ This is clearer than embedding a long inline script in `.codex-cage.yml`, and it
 
 When a Compose file lives under `.codex-cage/`, Codex Cage still runs Compose with the target repo as the project directory. Relative bind mounts like `./scripts/init.sql:/docker-entrypoint-initdb.d/init.sql:ro` resolve from the repo root during `codex-cage run`. If you run the same Compose file manually, pass `--project-directory <repo-root>` to match Codex Cage's behavior.
 
+## Execution Modes
+
+> Status: planned. Tracked in [#80](https://github.com/jhowliu/codex-cage/issues/80). Today Codex Cage always runs in Docker mode; direct mode is the design target for GitHub Actions.
+
+Codex Cage's isolation strategy depends on where it runs. The engine — bounded retry loop, independent review gate, secret guard, publish gate — is identical across modes; only the workspace isolation and service provisioning differ.
+
+- **Docker mode (default; local and self-hosted runners).** Codex Cage owns isolation: per-run volume clone, optional runtime image build, and Compose services started by the host-side orchestrator (see [Docker Compose Services](#docker-compose-services)). This is required wherever the host is not itself disposable — a laptop has no ephemeral VM, so the Docker sandbox is what keeps the agent off the host filesystem and credentials.
+- **Direct mode (GitHub Actions).** The runner's ephemeral VM already provides disposable isolation, so the inner Docker sandbox is skipped: Codex Cage clones on the runner and runs commands directly on the host through the same `ShellRunner` seam. Services come from GitHub Actions native `services:` containers, not Compose. Opt in via the execution-mode selector set by the workflow.
+
+Which `.codex-cage.yml` keys apply per mode:
+
+| Key | Docker mode | Direct mode |
+| --- | --- | --- |
+| `setup`, `verify` | yes | yes |
+| `agent`, `timeouts`, `pr`, `git`, `issue`, `guards` | yes | yes |
+| `services.compose`, `services.ready` | yes | ignored — declare services in the workflow `services:` block |
+| `runtime.image` | yes | use as the job `container:` image |
+| `runtime.dockerfile` (per-run build) | yes | not supported |
+
+In direct mode, running the Actions job inside the Codex Cage base image (`container:`) keeps the existing service DNS-name convention (`postgres`, `redis`) working, with service readiness expressed via service-container `--health-cmd`.
+
 ## Prompt Instructions
 
 Codex Cage relies on Codex CLI's native `AGENTS.md` handling for repository implementation guidance. It does not inject the contents of `AGENTS.md`, `.codex-cage/instructions.md`, `.github/copilot-instructions.md`, or `CLAUDE.md` into implementation or review prompts.

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,10 +57,43 @@ export const codexCageConfigSchema = z
         max_secret_fix_attempts: z.number().int().nonnegative().default(2),
       })
       .default(() => ({ max_secret_fix_attempts: 2 })),
+    execution: z.enum(["docker", "direct"]).optional(),
   })
   .passthrough();
 
 export type CodexCageConfig = z.infer<typeof codexCageConfigSchema>;
+
+export type ExecutionMode = "docker" | "direct";
+
+export const CODEX_CAGE_EXECUTION_ENV = "CODEX_CAGE_EXECUTION";
+
+const executionModes = new Set<ExecutionMode>(["docker", "direct"]);
+
+function isExecutionMode(value: string): value is ExecutionMode {
+  return executionModes.has(value as ExecutionMode);
+}
+
+/**
+ * Resolves the execution mode from the environment first, then config, then
+ * defaults to `docker`. An explicitly set but invalid env value is rejected so
+ * a typo in CI fails loudly instead of silently falling back.
+ */
+export function resolveExecutionMode(input: {
+  env?: Record<string, string | undefined> | undefined;
+  config?: { execution?: ExecutionMode | undefined } | undefined;
+}): ExecutionMode {
+  const fromEnv = input.env?.[CODEX_CAGE_EXECUTION_ENV];
+  if (fromEnv !== undefined && fromEnv !== "") {
+    if (!isExecutionMode(fromEnv)) {
+      throw new Error(
+        `${CODEX_CAGE_EXECUTION_ENV} must be "docker" or "direct", got "${fromEnv}".`,
+      );
+    }
+    return fromEnv;
+  }
+
+  return input.config?.execution ?? "docker";
+}
 
 export type ConfigParseResult = {
   config: CodexCageConfig;
@@ -78,6 +111,7 @@ const knownTopLevelKeys = new Set([
   "git",
   "issue",
   "guards",
+  "execution",
 ]);
 
 export function parseCodexCageConfig(input: unknown): ConfigParseResult {

--- a/src/sandbox-execution.ts
+++ b/src/sandbox-execution.ts
@@ -48,6 +48,35 @@ export function createDockerShellRunner(
   };
 }
 
+export function createHostShellRunner(
+  workspacePath: string,
+  env: Record<string, string> = {},
+): ShellRunner {
+  return {
+    async run(
+      command: string,
+      options: DockerCommandOptions = {},
+    ): Promise<CommandResult> {
+      const commandEnv = { ...env, ...(options.env ?? {}) };
+      const result = await execa(
+        hostCommandWithCodexAuth(command, options.codexAuthFilePath),
+        {
+          shell: true,
+          cwd: workspacePath,
+          env: commandEnv,
+          reject: false,
+        },
+      );
+
+      return {
+        exitCode: result.exitCode ?? 0,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      };
+    },
+  };
+}
+
 export async function requiredShell(
   shell: ShellRunner,
   command: string,
@@ -154,6 +183,24 @@ export function formatCommandLog(command: string, result: CommandResult): string
 
 export function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function hostCommandWithCodexAuth(
+  command: string,
+  codexAuthFilePath: string | undefined,
+): string {
+  if (codexAuthFilePath === undefined) {
+    return command;
+  }
+
+  const quoted = shellQuote(codexAuthFilePath);
+  return [
+    `if [ -f ${quoted} ] && [ -z "\${OPENAI_API_KEY:-}" ]; then mkdir -p "\${CODEX_HOME:-$HOME/.codex}"`,
+    `cp ${quoted} "\${CODEX_HOME:-$HOME/.codex}/auth.json"`,
+    `chmod 600 "\${CODEX_HOME:-$HOME/.codex}/auth.json"`,
+    "fi",
+    command,
+  ].join("; ");
 }
 
 function createShellCommandRunner(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { codexCageConfigSchema, parseCodexCageConfig } from "../src/config.js";
+import {
+  codexCageConfigSchema,
+  parseCodexCageConfig,
+  resolveExecutionMode,
+} from "../src/config.js";
 import { defaultSandboxImage } from "../src/docker.js";
 
 test("config schema accepts a minimal valid config", () => {
@@ -54,4 +58,50 @@ test("config schema preserves unknown keys for forward compatibility", () => {
   assert.deepEqual(result.warnings, [
     'Unknown config key "future_option" is not used by this version.',
   ]);
+});
+
+test("execution mode defaults to docker", () => {
+  assert.equal(resolveExecutionMode({}), "docker");
+  assert.equal(resolveExecutionMode({ env: {}, config: {} }), "docker");
+});
+
+test("execution mode reads from config when no env override", () => {
+  assert.equal(resolveExecutionMode({ config: { execution: "direct" } }), "direct");
+  assert.equal(resolveExecutionMode({ config: { execution: "docker" } }), "docker");
+});
+
+test("execution mode env overrides config", () => {
+  assert.equal(
+    resolveExecutionMode({
+      env: { CODEX_CAGE_EXECUTION: "direct" },
+      config: { execution: "docker" },
+    }),
+    "direct",
+  );
+});
+
+test("execution mode ignores empty env value and falls back", () => {
+  assert.equal(
+    resolveExecutionMode({
+      env: { CODEX_CAGE_EXECUTION: "" },
+      config: { execution: "direct" },
+    }),
+    "direct",
+  );
+});
+
+test("execution mode rejects an invalid env value", () => {
+  assert.throws(
+    () => resolveExecutionMode({ env: { CODEX_CAGE_EXECUTION: "vm" } }),
+    /must be "docker" or "direct"/,
+  );
+});
+
+test("config schema accepts an explicit execution mode", () => {
+  const config = codexCageConfigSchema.parse({
+    verify: ["npm test"],
+    execution: "direct",
+  });
+
+  assert.equal(config.execution, "direct");
 });

--- a/test/sandbox-execution.test.ts
+++ b/test/sandbox-execution.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createHostShellRunner } from "../src/sandbox-execution.js";
+
+async function withWorkspace(
+  fn: (workspacePath: string) => Promise<void>,
+): Promise<void> {
+  const dir = await realpath(await mkdtemp(join(tmpdir(), "codex-cage-host-")));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("host shell runner runs commands in the workspace directory", async () => {
+  await withWorkspace(async (workspacePath) => {
+    const runner = createHostShellRunner(workspacePath);
+
+    const result = await runner.run("pwd");
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout.trim(), workspacePath);
+  });
+});
+
+test("host shell runner surfaces non-zero exit codes without throwing", async () => {
+  await withWorkspace(async (workspacePath) => {
+    const runner = createHostShellRunner(workspacePath);
+
+    const result = await runner.run("exit 7");
+
+    assert.equal(result.exitCode, 7);
+  });
+});
+
+test("host shell runner merges base env with per-command env", async () => {
+  await withWorkspace(async (workspacePath) => {
+    const runner = createHostShellRunner(workspacePath, { BASE_VAR: "base" });
+
+    const result = await runner.run('printf "%s-%s" "$BASE_VAR" "$CMD_VAR"', {
+      env: { CMD_VAR: "cmd" },
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, "base-cmd");
+  });
+});
+
+test("host shell runner supports shell operators like the docker runner", async () => {
+  await withWorkspace(async (workspacePath) => {
+    const runner = createHostShellRunner(workspacePath);
+
+    const result = await runner.run("true && printf ok");
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, "ok");
+  });
+});


### PR DESCRIPTION
Implements #81 (part of the direct-execution-mode work in #80).

## What

Adds the engine groundwork for a second execution mode without changing any existing behavior:

- **`createHostShellRunner(workspacePath, env?)`** in `sandbox-execution.ts` — runs commands directly on the host via the shell at the workspace cwd, returning the same `CommandResult` shape as the Docker runner (exit codes surfaced, never throws). Merges base env with per-command env, and mirrors the Docker codex-auth handling for the host `CODEX_HOME`.
- **Execution-mode selector** in `config.ts` — `CODEX_CAGE_EXECUTION` env var + optional `execution` config key, resolved by `resolveExecutionMode` with precedence **env > config > `docker` default**. An explicitly set but invalid env value throws (fail loud in CI).

Downstream command construction (git/gh/review/codex-exec) is untouched because it depends only on `ShellRunner`. Docker mode is unchanged. Wiring direct mode into `run-workflow.ts` is #82.

Also documents the planned dual-mode design in `docs/workflow.md` (marked planned, tracked in #80).

## Tests

- `test/sandbox-execution.test.ts` (new): host runner cwd, non-zero exit pass-through, env merging, shell operators.
- `test/config.test.ts`: mode resolution (default/config/env-override/empty/invalid) and schema acceptance of `execution`.

Full suite green (116 tests), typecheck and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)