### PR TITLE
feat: branch run-workflow for direct execution mode

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -158,7 +158,9 @@ When a Compose file lives under `.codex-cage/`, Codex Cage still runs Compose wi
 
 ## Execution Modes
 
-> Status: planned. Tracked in [#80](https://github.com/jhowliu/codex-cage/issues/80). Today Codex Cage always runs in Docker mode; direct mode is the design target for GitHub Actions.
+> Status: in progress. Tracked in [#80](https://github.com/jhowliu/codex-cage/issues/80). The engine supports both modes; the GitHub Actions workflow that selects direct mode is still pending.
+
+Select the mode with the `CODEX_CAGE_EXECUTION` environment variable (`docker` or `direct`) or the `execution` key in `.codex-cage.yml`. The environment variable wins; both default to `docker`.
 
 Codex Cage's isolation strategy depends on where it runs. The engine — bounded retry loop, independent review gate, secret guard, publish gate — is identical across modes; only the workspace isolation and service provisioning differ.
 
@@ -167,13 +169,13 @@ Codex Cage's isolation strategy depends on where it runs. The engine — bounded
 
 Which `.codex-cage.yml` keys apply per mode:
 
-| Key | Docker mode | Direct mode |
-| --- | --- | --- |
-| `setup`, `verify` | yes | yes |
-| `agent`, `timeouts`, `pr`, `git`, `issue`, `guards` | yes | yes |
-| `services.compose`, `services.ready` | yes | ignored — declare services in the workflow `services:` block |
-| `runtime.image` | yes | use as the job `container:` image |
-| `runtime.dockerfile` (per-run build) | yes | not supported |
+| Key                                                 | Docker mode | Direct mode                                                  |
+| --------------------------------------------------- | ----------- | ------------------------------------------------------------ |
+| `setup`, `verify`                                   | yes         | yes                                                          |
+| `agent`, `timeouts`, `pr`, `git`, `issue`, `guards` | yes         | yes                                                          |
+| `services.compose`, `services.ready`                | yes         | ignored — declare services in the workflow `services:` block |
+| `runtime.image`                                     | yes         | use as the job `container:` image                            |
+| `runtime.dockerfile` (per-run build)                | yes         | not supported                                                |
 
 In direct mode, running the Actions job inside the Codex Cage base image (`container:`) keeps the existing service DNS-name convention (`postgres`, `redis`) working, with service readiness expressed via service-container `--health-cmd`.
 

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -412,7 +412,7 @@ function commandWithCodexAuth(
   ].join("; ");
 }
 
-function commandWithGitHubAuth(
+export function commandWithGitHubAuth(
   command: string,
   env: Record<string, string>,
 ): string {
@@ -432,7 +432,7 @@ function commandWithGitHubAuth(
     "EOF",
     'chmod 700 "$tmp_git_askpass"',
     'export GIT_ASKPASS="$tmp_git_askpass" GIT_TERMINAL_PROMPT=0',
-    'trap \'rm -f "$tmp_git_askpass"\' EXIT',
+    "trap 'rm -f \"$tmp_git_askpass\"' EXIT",
     command,
   ].join("\n");
 }

--- a/src/run-workflow.ts
+++ b/src/run-workflow.ts
@@ -4,11 +4,12 @@ import {
   hasComposeServices,
   type ComposeProject,
 } from "./compose.js";
-import type { CodexCageConfig } from "./config.js";
+import type { CodexCageConfig, ExecutionMode } from "./config.js";
 import type { CommandCredentialIntent, RunCredentials } from "./credentials.js";
 import {
   buildRuntimeImage,
   createDockerSandbox,
+  unauthenticatedRemoteUrl,
   type DockerCommandOptions,
   type DockerSandbox,
   type DockerSandboxOptions,
@@ -31,10 +32,13 @@ import { buildImplementationPrompt } from "./run/prompts.js";
 import {
   codexExecCommand,
   createDockerShellRunner,
+  createHostShellRunner,
+  createHostWorkspace,
   formatCommandLog,
   readCurrentDiff,
   requiredShell,
   shellQuote,
+  type HostWorkspace,
   type ShellRunner,
 } from "./sandbox-execution.js";
 import type { FailureCode, PhaseName, RunStore } from "./state.js";
@@ -93,6 +97,7 @@ export type RuntimeContext = {
   branchName: string;
   runtimeImage: RuntimeImageBuildResult & { source: "configured" | "built" };
   promptContext: PromptContext;
+  executionMode: ExecutionMode;
 };
 
 export type RunWorkflowInput = {
@@ -104,6 +109,8 @@ export type RunWorkflowInput = {
     sandbox: DockerSandbox,
     env: Record<string, string>,
   ) => ShellRunner;
+  createHostWorkspace?: typeof createHostWorkspace;
+  createHostShellRunner?: typeof createHostShellRunner;
   createComposeProject?: typeof createComposeProject;
   runIndependentReview?: typeof runIndependentReview;
   publishSuccessfulRun?: typeof publishSuccessfulRun;
@@ -115,6 +122,8 @@ export async function runWorkflow(input: RunWorkflowInput): Promise<RunCodexCage
   const createSandbox = input.createDockerSandbox ?? createDockerSandbox;
   const buildImage = input.buildRuntimeImage ?? buildRuntimeImage;
   const makeShellRunner = input.createShellRunner ?? createDockerShellRunner;
+  const makeHostWorkspace = input.createHostWorkspace ?? createHostWorkspace;
+  const makeHostShellRunner = input.createHostShellRunner ?? createHostShellRunner;
   const makeComposeProject = input.createComposeProject ?? createComposeProject;
   const review = input.runIndependentReview ?? runIndependentReview;
   const publish = input.publishSuccessfulRun ?? publishSuccessfulRun;
@@ -124,6 +133,7 @@ export async function runWorkflow(input: RunWorkflowInput): Promise<RunCodexCage
   let sandbox: DockerSandbox | null = null;
   let shell: ShellRunner | null = null;
   let compose: ComposeProject | null = null;
+  let hostWorkspace: HostWorkspace | null = null;
 
   try {
     await journal.startRun();
@@ -145,86 +155,37 @@ export async function runWorkflow(input: RunWorkflowInput): Promise<RunCodexCage
       ].join("\n");
     });
 
-    const runtimeDockerfile = context.config.runtime.dockerfile;
-
-    if (runtimeDockerfile !== null) {
-      try {
-        context.runtimeImage = await journal.runPhase("runtime_image", async () => {
-          const result = await buildImage({
-            runId: context.runId,
-            dockerfilePath: resolve(context.cwd, runtimeDockerfile),
-            contextPath: resolve(context.cwd, ".codex-cage"),
-          });
-
-          return {
-            log: [
-              `Built runtime image: ${result.image}`,
-              `Dockerfile: ${result.dockerfilePath}`,
-              `Build context: ${result.contextPath}`,
-            ].join("\n"),
-            value: { ...result, source: "built" as const },
-          };
-        });
-      } catch (error) {
-        throw new RunFailureError("runtime_image_failed", formatError(error));
-      }
-    }
-
-    await journal.writeJsonArtifact("runtime-image.json", context.runtimeImage);
-
-    if (hasComposeServices(context.config.services)) {
-      const composeFile = context.config.services.compose;
-
-      if (composeFile === null) {
-        throw new RunFailureError("invalid_config", "Compose file is not configured.");
-      }
-
-      compose = makeComposeProject({
-        runId: context.runId,
-        composeFile: resolve(context.cwd, composeFile),
-        projectDirectory: context.cwd,
-        readyCommands: context.config.services.ready,
-      });
-      try {
-        await journal.runPhase("setup", async () => {
-          await compose?.up();
-          await compose?.waitUntilReady();
-          return "Compose services are ready.";
-        });
-      } catch (error) {
-        throw new RunFailureError("setup_failed", formatError(error));
-      }
-    }
-
-    const cloneCredentials = runtimeCommandCredentials("clone", context);
-    const sandboxOptions: DockerSandboxOptions = {
-      runId: context.runId,
-      cloneUrl: context.authenticatedRepo.cloneUrl,
-      image: context.runtimeImage.image,
-      env: cloneCredentials.env ?? {},
-    };
-
-    if (compose !== null) {
-      sandboxOptions.serviceNetworkName = compose.networkName;
-    }
-
-    sandbox = createSandbox(sandboxOptions);
-    shell = makeShellRunner(sandbox, {});
-    const shellRunner = shell;
-
-    await journal.setRunStatus("cloning");
-    await journal.runPhase("cloning", async () => {
-      await sandbox?.create();
-      await sandbox?.cloneRepository();
-      return await requiredShell(
-        shellRunner,
-        `git fetch origin ${shellQuote(context.baseBranch)} && git checkout ${shellQuote(
-          context.baseBranch,
-        )} && git pull --ff-only origin ${shellQuote(context.baseBranch)}`,
+    if (context.executionMode === "direct") {
+      shell = await provisionDirectWorkspace({
+        context,
+        journal,
         redactor,
-        runtimeCommandCredentials("clone", context),
-      );
-    });
+        createHostWorkspace: makeHostWorkspace,
+        createHostShellRunner: makeHostShellRunner,
+        registerWorkspace: (workspace) => {
+          hostWorkspace = workspace;
+        },
+      });
+    } else {
+      const provisioned = await provisionDockerSandbox({
+        context,
+        journal,
+        redactor,
+        createSandbox,
+        buildImage,
+        makeShellRunner,
+        makeComposeProject,
+        registerCompose: (project) => {
+          compose = project;
+        },
+        registerSandbox: (created) => {
+          sandbox = created;
+        },
+      });
+      shell = provisioned;
+    }
+
+    const shellRunner = shell;
 
     if (context.config.setup.length > 0) {
       await journal.setRunStatus("setup");
@@ -283,8 +244,148 @@ export async function runWorkflow(input: RunWorkflowInput): Promise<RunCodexCage
 
     return runResult;
   } finally {
-    await cleanupRuntime(compose, sandbox);
+    await cleanupRuntime(compose, sandbox, hostWorkspace);
   }
+}
+
+async function provisionDockerSandbox(input: {
+  context: RuntimeContext;
+  journal: RunJournal;
+  redactor: (value: string) => string;
+  createSandbox: (options: DockerSandboxOptions) => DockerSandbox;
+  buildImage: typeof buildRuntimeImage;
+  makeShellRunner: (sandbox: DockerSandbox, env: Record<string, string>) => ShellRunner;
+  makeComposeProject: typeof createComposeProject;
+  registerCompose: (project: ComposeProject) => void;
+  registerSandbox: (sandbox: DockerSandbox) => void;
+}): Promise<ShellRunner> {
+  const { context, journal, redactor } = input;
+  const runtimeDockerfile = context.config.runtime.dockerfile;
+
+  if (runtimeDockerfile !== null) {
+    try {
+      context.runtimeImage = await journal.runPhase("runtime_image", async () => {
+        const result = await input.buildImage({
+          runId: context.runId,
+          dockerfilePath: resolve(context.cwd, runtimeDockerfile),
+          contextPath: resolve(context.cwd, ".codex-cage"),
+        });
+
+        return {
+          log: [
+            `Built runtime image: ${result.image}`,
+            `Dockerfile: ${result.dockerfilePath}`,
+            `Build context: ${result.contextPath}`,
+          ].join("\n"),
+          value: { ...result, source: "built" as const },
+        };
+      });
+    } catch (error) {
+      throw new RunFailureError("runtime_image_failed", formatError(error));
+    }
+  }
+
+  await journal.writeJsonArtifact("runtime-image.json", context.runtimeImage);
+
+  let compose: ComposeProject | null = null;
+
+  if (hasComposeServices(context.config.services)) {
+    const composeFile = context.config.services.compose;
+
+    if (composeFile === null) {
+      throw new RunFailureError("invalid_config", "Compose file is not configured.");
+    }
+
+    compose = input.makeComposeProject({
+      runId: context.runId,
+      composeFile: resolve(context.cwd, composeFile),
+      projectDirectory: context.cwd,
+      readyCommands: context.config.services.ready,
+    });
+    input.registerCompose(compose);
+    try {
+      await journal.runPhase("setup", async () => {
+        await compose?.up();
+        await compose?.waitUntilReady();
+        return "Compose services are ready.";
+      });
+    } catch (error) {
+      throw new RunFailureError("setup_failed", formatError(error));
+    }
+  }
+
+  const cloneCredentials = runtimeCommandCredentials("clone", context);
+  const sandboxOptions: DockerSandboxOptions = {
+    runId: context.runId,
+    cloneUrl: context.authenticatedRepo.cloneUrl,
+    image: context.runtimeImage.image,
+    env: cloneCredentials.env ?? {},
+  };
+
+  if (compose !== null) {
+    sandboxOptions.serviceNetworkName = compose.networkName;
+  }
+
+  const sandbox = input.createSandbox(sandboxOptions);
+  input.registerSandbox(sandbox);
+  const shell = input.makeShellRunner(sandbox, {});
+
+  await journal.setRunStatus("cloning");
+  await journal.runPhase("cloning", async () => {
+    await sandbox.create();
+    await sandbox.cloneRepository();
+    return await requiredShell(
+      shell,
+      `git fetch origin ${shellQuote(context.baseBranch)} && git checkout ${shellQuote(
+        context.baseBranch,
+      )} && git pull --ff-only origin ${shellQuote(context.baseBranch)}`,
+      redactor,
+      cloneCredentials,
+    );
+  });
+
+  return shell;
+}
+
+async function provisionDirectWorkspace(input: {
+  context: RuntimeContext;
+  journal: RunJournal;
+  redactor: (value: string) => string;
+  createHostWorkspace: typeof createHostWorkspace;
+  createHostShellRunner: typeof createHostShellRunner;
+  registerWorkspace: (workspace: HostWorkspace) => void;
+}): Promise<ShellRunner> {
+  const { context, journal, redactor } = input;
+
+  await journal.writeJsonArtifact("runtime-image.json", context.runtimeImage);
+
+  const cloneCredentials = runtimeCommandCredentials("clone", context);
+  const workspace = await input.createHostWorkspace(context.runId);
+  input.registerWorkspace(workspace);
+  const shell = input.createHostShellRunner(workspace.workspacePath, {});
+
+  await journal.setRunStatus("cloning");
+  await journal.runPhase("cloning", async () => {
+    const remoteUrl = unauthenticatedRemoteUrl(context.authenticatedRepo.cloneUrl);
+    await requiredShell(
+      shell,
+      `git clone ${shellQuote(remoteUrl)} . && git remote set-url origin ${shellQuote(
+        remoteUrl,
+      )}`,
+      redactor,
+      cloneCredentials,
+    );
+    return await requiredShell(
+      shell,
+      `git fetch origin ${shellQuote(context.baseBranch)} && git checkout ${shellQuote(
+        context.baseBranch,
+      )} && git pull --ff-only origin ${shellQuote(context.baseBranch)}`,
+      redactor,
+      cloneCredentials,
+    );
+  });
+
+  return shell;
 }
 
 function runtimeCommandCredentials(
@@ -468,6 +569,7 @@ function failureCodeFromError(error: unknown): FailureCode {
 async function cleanupRuntime(
   compose: ComposeProject | null,
   sandbox: DockerSandbox | null,
+  hostWorkspace: HostWorkspace | null,
 ): Promise<void> {
   const errors: string[] = [];
 
@@ -482,6 +584,14 @@ async function cleanupRuntime(
   if (sandbox !== null) {
     try {
       await sandbox.cleanup();
+    } catch (error) {
+      errors.push(formatError(error));
+    }
+  }
+
+  if (hostWorkspace !== null) {
+    try {
+      await hostWorkspace.cleanup();
     } catch (error) {
       errors.push(formatError(error));
     }

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,7 +4,11 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import YAML from "yaml";
 import type { createComposeProject } from "./compose.js";
-import { parseCodexCageConfig, type CodexCageConfig } from "./config.js";
+import {
+  parseCodexCageConfig,
+  resolveExecutionMode,
+  type CodexCageConfig,
+} from "./config.js";
 import { prepareRunCredentials } from "./credentials.js";
 import {
   type buildRuntimeImage,
@@ -19,6 +23,7 @@ import { createAuthenticatedRepo, resolveTargetRepo } from "./repo.js";
 import type { runIndependentReview } from "./review.js";
 import { RunFailureError } from "./run/errors.js";
 import { openRunStore } from "./state.js";
+import type { createHostShellRunner, createHostWorkspace } from "./sandbox-execution.js";
 import {
   runWorkflow,
   type RunCodexCageResult,
@@ -50,6 +55,8 @@ export type RunCodexCageDependencies = {
     sandbox: DockerSandbox,
     env: Record<string, string>,
   ) => ShellRunner;
+  createHostWorkspace?: typeof createHostWorkspace;
+  createHostShellRunner?: typeof createHostShellRunner;
   createComposeProject?: typeof createComposeProject;
   runIndependentReview?: typeof runIndependentReview;
   publishSuccessfulRun?: typeof publishSuccessfulRun;
@@ -82,6 +89,12 @@ export async function runCodexCage(
       ...(dependencies.createShellRunner === undefined
         ? {}
         : { createShellRunner: dependencies.createShellRunner }),
+      ...(dependencies.createHostWorkspace === undefined
+        ? {}
+        : { createHostWorkspace: dependencies.createHostWorkspace }),
+      ...(dependencies.createHostShellRunner === undefined
+        ? {}
+        : { createHostShellRunner: dependencies.createHostShellRunner }),
       ...(dependencies.createComposeProject === undefined
         ? {}
         : { createComposeProject: dependencies.createComposeProject }),
@@ -147,6 +160,10 @@ async function prepareRuntimeContext(
     source: "configured" as const,
   };
   const promptContext = await buildPromptContext(cwd);
+  const executionMode = resolveExecutionMode({
+    env: process.env,
+    config: configResult.config,
+  });
 
   return {
     cwd,
@@ -163,6 +180,7 @@ async function prepareRuntimeContext(
     branchName,
     runtimeImage,
     promptContext,
+    executionMode,
   };
 }
 

--- a/src/sandbox-execution.ts
+++ b/src/sandbox-execution.ts
@@ -1,5 +1,9 @@
 import { execa } from "execa";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+  commandWithGitHubAuth,
   dockerRunArgs,
   type DockerCommandOptions,
   type DockerSandbox,
@@ -10,6 +14,26 @@ import type { ReviewAgentRunner } from "./review.js";
 export type ShellRunner = {
   run(command: string, options?: DockerCommandOptions): Promise<CommandResult>;
 };
+
+export type HostWorkspace = {
+  workspacePath: string;
+  cleanup: () => Promise<void>;
+};
+
+/**
+ * Creates an empty host directory to clone the target repository into for
+ * direct-mode runs, where the runner (not Docker) provides isolation.
+ */
+export async function createHostWorkspace(runId: string): Promise<HostWorkspace> {
+  const workspacePath = await mkdtemp(join(tmpdir(), `codex-cage-${runId}-`));
+
+  return {
+    workspacePath,
+    async cleanup(): Promise<void> {
+      await rm(workspacePath, { recursive: true, force: true });
+    },
+  };
+}
 
 export function createDockerShellRunner(
   sandbox: DockerSandbox,
@@ -59,7 +83,10 @@ export function createHostShellRunner(
     ): Promise<CommandResult> {
       const commandEnv = { ...env, ...(options.env ?? {}) };
       const result = await execa(
-        hostCommandWithCodexAuth(command, options.codexAuthFilePath),
+        commandWithGitHubAuth(
+          hostCommandWithCodexAuth(command, options.codexAuthFilePath),
+          commandEnv,
+        ),
         {
           shell: true,
           cwd: workspacePath,

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -405,6 +405,119 @@ verify:
   }
 });
 
+test("runCodexCage runs direct mode on the host without Docker resources", async () => {
+  const cwd = await createProject(`
+execution: direct
+setup:
+  - npm install
+verify:
+  - npm test
+services:
+  compose: .codex-cage/docker-compose.yml
+  ready:
+    - pg_isready
+`);
+  const shell = shellRunner(
+    new Map([
+      ["git clone", commandResult()],
+      ["git fetch origin", commandResult()],
+      ["npm install", commandResult("setup passed")],
+      ["codex exec", commandResult("implemented")],
+      ["npm test", commandResult("tests passed")],
+      [
+        "git add --intent-to-add",
+        commandResult(`diff --git a/src/app.ts b/src/app.ts
+@@ -1 +1,2 @@
+ export const ok = true;
++export const changed = true;
+`),
+      ],
+    ]),
+  );
+
+  let workspaceRunId = "";
+  let hostShellWorkspacePath = "";
+  let cleanupCalls = 0;
+
+  try {
+    const result = await runCodexCage(
+      {
+        cwd,
+        issueUrl: issue.url,
+      },
+      {
+        generateRunId: () => "run-direct-1",
+        readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
+        findCodexAuthFile: async () => null,
+        fetchIssueContext: async () => issue,
+        resolveTargetRepo: async () => repoResolution,
+        createAuthenticatedRepo: () => ({
+          repo,
+          cloneUrl: "https://github.com/jhowliu/codex-cage.git",
+          redactedCloneUrl: "https://github.com/jhowliu/codex-cage.git",
+        }),
+        createDockerSandbox: () => {
+          throw new Error("Docker sandbox must not be created in direct mode.");
+        },
+        createComposeProject: () => {
+          throw new Error("Compose must not be started in direct mode.");
+        },
+        createHostWorkspace: async (runId: string) => {
+          workspaceRunId = runId;
+          return {
+            workspacePath: "/tmp/codex-cage-direct",
+            cleanup: async () => {
+              cleanupCalls += 1;
+            },
+          };
+        },
+        createHostShellRunner: (workspacePath: string) => {
+          hostShellWorkspacePath = workspacePath;
+          return shell;
+        },
+        runIndependentReview: async () => passingReview(),
+        publishSuccessfulRun: async (input) => ({
+          branchName: input.branchName ?? "codex-cage/gh-26-run-direct",
+          commitMessage: "#26 Wire run command",
+          prTitle: "#26 Wire run command",
+          prBody: "body",
+          prUrl: "https://github.com/jhowliu/codex-cage/pull/99",
+        }),
+      },
+    );
+
+    assert.deepEqual(result, {
+      runId: "run-direct-1",
+      status: "succeeded",
+      failureCode: null,
+      prUrl: "https://github.com/jhowliu/codex-cage/pull/99",
+    });
+    assert.equal(workspaceRunId, "run-direct-1");
+    assert.equal(hostShellWorkspacePath, "/tmp/codex-cage-direct");
+    assert.equal(cleanupCalls, 1);
+    assert.ok(
+      shell.commands.some(
+        (command) =>
+          command.includes("git clone") &&
+          command.includes("https://github.com/jhowliu/codex-cage.git"),
+      ),
+      "direct mode should clone via the host shell",
+    );
+
+    const store = await openRunStore(cwd);
+    const details = store.getRunDetails("run-direct-1");
+    store.close();
+
+    assert.equal(details.run.status, "succeeded");
+    assert.deepEqual(
+      details.phases.map((phase) => phase.name),
+      ["preflight", "cloning", "setup", "implement", "verify", "review", "pr"],
+    );
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
 test("runCodexCage redacts credential-bearing publish failures in artifacts", async () => {
   const cwd = await createProject(`
 verify:

--- a/test/sandbox-execution.test.ts
+++ b/test/sandbox-execution.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
-import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { mkdtemp, readdir, realpath, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { createHostShellRunner } from "../src/sandbox-execution.js";
+import { createHostShellRunner, createHostWorkspace } from "../src/sandbox-execution.js";
 
 async function withWorkspace(
   fn: (workspacePath: string) => Promise<void>,
@@ -59,4 +59,39 @@ test("host shell runner supports shell operators like the docker runner", async 
     assert.equal(result.exitCode, 0);
     assert.equal(result.stdout, "ok");
   });
+});
+
+test("host shell runner configures git askpass when a GitHub token is present", async () => {
+  await withWorkspace(async (workspacePath) => {
+    const runner = createHostShellRunner(workspacePath, {
+      GITHUB_TOKEN: "secret-token",
+    });
+
+    const result = await runner.run('"$GIT_ASKPASS" Username; "$GIT_ASKPASS" Password');
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, "x-access-token\nsecret-token");
+  });
+});
+
+test("host shell runner leaves git askpass unset without a GitHub token", async () => {
+  await withWorkspace(async (workspacePath) => {
+    const runner = createHostShellRunner(workspacePath);
+
+    const result = await runner.run('printf "%s" "${GIT_ASKPASS:-unset}"');
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, "unset");
+  });
+});
+
+test("createHostWorkspace makes an empty directory and cleans it up", async () => {
+  const workspace = await createHostWorkspace("run-host-workspace");
+
+  const stats = await stat(workspace.workspacePath);
+  assert.equal(stats.isDirectory(), true);
+  assert.deepEqual(await readdir(workspace.workspacePath), []);
+
+  await workspace.cleanup();
+  await assert.rejects(() => stat(workspace.workspacePath), { code: "ENOENT" });
 });


### PR DESCRIPTION
Implements #82 (part of the direct-execution-mode work in #80). Builds on the host `ShellRunner` + execution-mode selector from #81/#85.

## What

`runWorkflow` now selects workspace provisioning by `context.executionMode`:

- **Docker mode** (default, behavior unchanged) — extracted into `provisionDockerSandbox`: runtime image build, Compose services, Docker sandbox + per-run volume clone.
- **Direct mode** — `provisionDirectWorkspace`: clones the repo into a host workspace (`createHostWorkspace`) and runs everything on the host via `createHostShellRunner`. Skips runtime image build and Compose; `.codex-cage.yml` `services.compose`/`runtime.dockerfile` are ignored (services come from the workflow `services:` block).

The shared engine — setup, bounded retry loop, secret guard, independent review, publish gate — is unchanged and runs identically in both modes because it only depends on `ShellRunner`.

Supporting changes:
- Host shell runner now wraps commands with the GitHub askpass prelude (`commandWithGitHubAuth`, exported from `docker.ts` and reused) so host `git clone`/`fetch`/`push` authenticate the same way the Docker runner does.
- `createHostWorkspace` (mkdtemp + cleanup); host workspace is torn down in `finally`.
- `executionMode` resolved in `prepareRuntimeContext` (env > config > docker) and added to `RuntimeContext`.

## Tests

- `test/run.test.ts`: direct-mode happy path — asserts the same phase sequence (`preflight → cloning → setup → implement → verify → review → pr`), a successful PR result, that `createDockerSandbox`/`createComposeProject` are **never** called (they throw if invoked), that the host clone uses the host shell + unauthenticated remote URL, and that the workspace is cleaned up.
- `test/sandbox-execution.test.ts`: host runner configures `GIT_ASKPASS` (x-access-token + token) when a GitHub token is present and leaves it unset otherwise; `createHostWorkspace` makes an empty dir and removes it on cleanup.

Full suite green (120 tests), typecheck and prettier clean. Docker mode untouched.

The GitHub Actions workflow that selects direct mode is #84 (depends on this and #83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)