### PR TITLE
feat: emit deterministic CI outcome signal from run command

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -179,6 +179,24 @@ Which `.codex-cage.yml` keys apply per mode:
 
 In direct mode, running the Actions job inside the Codex Cage base image (`container:`) keeps the existing service DNS-name convention (`postgres`, `redis`) working, with service readiness expressed via service-container `--health-cmd`.
 
+### CI Outcome Signal
+
+For automation, `codex-cage run` emits a deterministic outcome so a workflow can branch on success or failure:
+
+- **Exit code.** The process exits non-zero when the run fails and zero when it succeeds.
+- **Result file.** Pass `--result-json <path>` (or set `CODEX_CAGE_RESULT_FILE`; the flag wins) to write the run result as JSON on both success and failure:
+
+  ```json
+  {
+    "runId": "run-20260704-abcdef",
+    "status": "succeeded",
+    "failureCode": null,
+    "prUrl": "https://github.com/OWNER/REPO/pull/123"
+  }
+  ```
+
+  `status` is `succeeded` or `failed`; `failureCode` is `null` on success and a failure code (for example `verify_failed`, `review_blocking`) otherwise; `prUrl` is `null` unless a PR was opened.
+
 ## Prompt Instructions
 
 Codex Cage relies on Codex CLI's native `AGENTS.md` handling for repository implementation guidance. It does not inject the contents of `AGENTS.md`, `.codex-cage/instructions.md`, `.github/copilot-instructions.md`, or `CLAUDE.md` into implementation or review prompts.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,9 +1,13 @@
 import { Command } from "commander";
+import { writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import { cleanupManagedDockerResources, type CleanupDockerReport } from "./docker.js";
 import { initProject } from "./init.js";
-import { runCodexCage, type RunProgressEvent } from "./run.js";
+import { runCodexCage, type RunCodexCageResult, type RunProgressEvent } from "./run.js";
 import { openRunStore } from "./state.js";
 import { readPackageVersion } from "./version.js";
+
+export const RESULT_FILE_ENV = "CODEX_CAGE_RESULT_FILE";
 
 export type CliDependencies = {
   runCodexCage?: typeof runCodexCage;
@@ -46,6 +50,10 @@ export function createCli(dependencies: CliDependencies = {}): Command {
     .option("--base <branch>", "base branch override")
     .option("--model <model>", "Codex model override")
     .option("--draft", "create a draft pull request")
+    .option(
+      "--result-json <path>",
+      `write the machine-readable run result to <path> (also settable via ${RESULT_FILE_ENV})`,
+    )
     .action(
       async (
         issueArgument: string | undefined,
@@ -55,6 +63,7 @@ export function createCli(dependencies: CliDependencies = {}): Command {
           base?: string;
           model?: string;
           draft?: boolean;
+          resultJson?: string;
         },
         command: Command,
       ) => {
@@ -94,6 +103,15 @@ export function createCli(dependencies: CliDependencies = {}): Command {
 
         if (result.prUrl !== null) {
           console.log(`${stdoutColor.label("PR")}: ${stdoutColor.link(result.prUrl)}`);
+        }
+
+        const resultPath = options.resultJson ?? process.env[RESULT_FILE_ENV];
+        if (resultPath !== undefined && resultPath !== "") {
+          await writeRunResultFile(resultPath, result);
+        }
+
+        if (result.status === "failed") {
+          process.exitCode = 1;
         }
       },
     );
@@ -236,6 +254,20 @@ function removeUndefinedProperties<TValue extends Record<string, unknown>>(
   return Object.fromEntries(
     Object.entries(value).filter(([, entry]) => entry !== undefined),
   ) as TValue;
+}
+
+async function writeRunResultFile(
+  path: string,
+  result: RunCodexCageResult,
+): Promise<void> {
+  const payload: RunCodexCageResult = {
+    runId: result.runId,
+    status: result.status,
+    failureCode: result.failureCode,
+    prUrl: result.prUrl,
+  };
+
+  await writeFile(resolve(path), `${JSON.stringify(payload, null, 2)}\n`, "utf8");
 }
 
 function formatCleanupReport(

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -8,6 +8,35 @@ import { fileURLToPath } from "node:url";
 import { createCli } from "../src/commands.js";
 import type { RunCommandOptions, RunCodexCageResult } from "../src/run.js";
 import { openRunStore } from "../src/state.js";
+
+async function runCliInProcess(
+  args: string[],
+  result: RunCodexCageResult,
+): Promise<{ exitCode: number | string | undefined; calls: RunCommandOptions[] }> {
+  const calls: RunCommandOptions[] = [];
+  const originalConsoleLog = console.log;
+  const originalExitCode = process.exitCode;
+  process.exitCode = 0;
+
+  const program = createCli({
+    runCodexCage: async (input): Promise<RunCodexCageResult> => {
+      calls.push(input);
+      return result;
+    },
+  });
+
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => undefined, writeErr: () => undefined });
+  console.log = () => undefined;
+
+  try {
+    await program.parseAsync(args, { from: "user" });
+    return { exitCode: process.exitCode, calls };
+  } finally {
+    console.log = originalConsoleLog;
+    process.exitCode = originalExitCode;
+  }
+}
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const cliPath = join(testDir, "..", "src", "cli.js");
@@ -57,6 +86,7 @@ test("command help is available for commands", () => {
 test("run accepts a positional issue URL", async () => {
   const calls: RunCommandOptions[] = [];
   const originalConsoleLog = console.log;
+  const originalExitCode = process.exitCode;
   const program = createCli({
     runCodexCage: async (input): Promise<RunCodexCageResult> => {
       calls.push(input);
@@ -85,6 +115,7 @@ test("run accepts a positional issue URL", async () => {
     );
   } finally {
     console.log = originalConsoleLog;
+    process.exitCode = originalExitCode;
   }
 
   assert.deepEqual(calls, [
@@ -98,6 +129,7 @@ test("run accepts a positional issue URL", async () => {
 test("run keeps the --issue option for compatibility", async () => {
   const calls: RunCommandOptions[] = [];
   const originalConsoleLog = console.log;
+  const originalExitCode = process.exitCode;
   const program = createCli({
     runCodexCage: async (input): Promise<RunCodexCageResult> => {
       calls.push(input);
@@ -121,6 +153,7 @@ test("run keeps the --issue option for compatibility", async () => {
     );
   } finally {
     console.log = originalConsoleLog;
+    process.exitCode = originalExitCode;
   }
 
   assert.deepEqual(calls, [
@@ -128,6 +161,92 @@ test("run keeps the --issue option for compatibility", async () => {
       issueUrl: "https://github.com/jhowliu/codex-cage/issues/35",
     },
   ]);
+});
+
+test("run writes the result file and exits zero on success", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "codex-cage-cli-result-"));
+  const resultPath = join(cwd, "result.json");
+
+  try {
+    const successResult: RunCodexCageResult = {
+      runId: "run-ok",
+      status: "succeeded",
+      failureCode: null,
+      prUrl: "https://github.com/jhowliu/codex-cage/pull/7",
+    };
+    const { exitCode } = await runCliInProcess(
+      [
+        "run",
+        "https://github.com/jhowliu/codex-cage/issues/7",
+        "--result-json",
+        resultPath,
+      ],
+      successResult,
+    );
+
+    assert.equal(exitCode, 0);
+    assert.deepEqual(JSON.parse(await readFile(resultPath, "utf8")), successResult);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("run writes the result file and exits non-zero on failure", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "codex-cage-cli-result-"));
+  const resultPath = join(cwd, "result.json");
+
+  try {
+    const failureResult: RunCodexCageResult = {
+      runId: "run-fail",
+      status: "failed",
+      failureCode: "verify_failed",
+      prUrl: null,
+    };
+    const { exitCode } = await runCliInProcess(
+      [
+        "run",
+        "https://github.com/jhowliu/codex-cage/issues/8",
+        "--result-json",
+        resultPath,
+      ],
+      failureResult,
+    );
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(JSON.parse(await readFile(resultPath, "utf8")), failureResult);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("run reads the result file path from the environment", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "codex-cage-cli-result-"));
+  const resultPath = join(cwd, "env-result.json");
+  const previous = process.env.CODEX_CAGE_RESULT_FILE;
+  process.env.CODEX_CAGE_RESULT_FILE = resultPath;
+
+  try {
+    const failureResult: RunCodexCageResult = {
+      runId: "run-env",
+      status: "failed",
+      failureCode: "review_blocking",
+      prUrl: null,
+    };
+    const { exitCode } = await runCliInProcess(
+      ["run", "https://github.com/jhowliu/codex-cage/issues/9"],
+      failureResult,
+    );
+
+    assert.equal(exitCode, 1);
+    assert.deepEqual(JSON.parse(await readFile(resultPath, "utf8")), failureResult);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.CODEX_CAGE_RESULT_FILE;
+    } else {
+      process.env.CODEX_CAGE_RESULT_FILE = previous;
+    }
+    await rm(cwd, { recursive: true, force: true });
+  }
 });
 
 test("runs list and show read local run metadata", async () => {


### PR DESCRIPTION
Implements #83 (part of #80). Gives `codex-cage run` a deterministic, machine-readable outcome so the GitHub Actions workflow (#84) can branch on success vs failure.

## What

- **Exit code.** `run` sets `process.exitCode = 1` when the run fails and leaves it zero on success. Uses `process.exitCode` (not `process.exit`) so stdout/stderr still flush.
- **Result file.** New `--result-json <path>` option, with `CODEX_CAGE_RESULT_FILE` env fallback (flag wins). Writes the run result as pretty JSON on **both** success and failure:
  ```json
  { "runId": "...", "status": "succeeded", "failureCode": null, "prUrl": "https://.../pull/123" }
  ```
  `status` is `succeeded`/`failed`; `failureCode` is `null` on success or a code like `verify_failed`/`review_blocking`; `prUrl` is `null` unless a PR was opened.
- Human-facing CLI output is unchanged; the file/exit-code are additive.
- Documented under **CI Outcome Signal** in `docs/workflow.md`.

Scope is intentionally the CLI layer only — no changes to `run-workflow.ts`/`run.ts`, since the result is already returned as `RunCodexCageResult`.

## Tests

`test/cli.test.ts`:
- writes the result file and exits **0** on success
- writes the result file and exits **1** on failure
- reads the result path from `CODEX_CAGE_RESULT_FILE`

The two existing in-process `run` tests now save/restore `process.exitCode` so the new exit-code behavior doesn't leak into the test runner.

Full suite green (123 tests), typecheck and prettier clean.

## Next

Unblocks #84 (the `issues: labeled` workflow), which will call `run --result-json` and map the outcome to the label state machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)