### PR TITLE
feat: add issue-label workflow for direct-mode runs

### DIFF
--- a/.codex-cage.yml
+++ b/.codex-cage.yml
@@ -1,0 +1,8 @@
+setup:
+  - npm ci
+
+verify:
+  - npm test
+
+git:
+  base: main

--- a/.github/workflows/issue-run.yml
+++ b/.github/workflows/issue-run.yml
@@ -29,7 +29,6 @@ jobs:
       GH_TOKEN: ${{ secrets.CODEX_CAGE_GITHUB_TOKEN }}
       ISSUE_NUMBER: ${{ github.event.issue.number }}
       ISSUE_URL: ${{ github.event.issue.html_url }}
-      RESULT_FILE: ${{ runner.temp }}/result.json
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Mark issue in progress
@@ -62,12 +61,12 @@ jobs:
           } > .codex-cage.env
 
       - name: Run Codex Cage
-        run: node dist/src/cli.js run "$ISSUE_URL" --result-json "$RESULT_FILE"
+        run: node dist/src/cli.js run "$ISSUE_URL" --result-json "$RUNNER_TEMP/result.json"
 
       - name: Report failure
         if: failure()
         run: |
-          FAILURE_CODE=$(jq -r '.failureCode // "unknown"' "$RESULT_FILE" 2>/dev/null || echo unknown)
+          FAILURE_CODE=$(jq -r '.failureCode // "unknown"' "$RUNNER_TEMP/result.json" 2>/dev/null || echo unknown)
           BODY="Codex Cage run failed (\`${FAILURE_CODE}\`). [View workflow run](${RUN_URL})."
           SUMMARY_FILE=$(ls .codex-cage/runs/*/summary.md 2>/dev/null | head -n1 || true)
           if [ -n "$SUMMARY_FILE" ]; then

--- a/.github/workflows/issue-run.yml
+++ b/.github/workflows/issue-run.yml
@@ -1,0 +1,92 @@
+name: Codex Cage issue run
+
+# Label an issue with `codex-cage:run` to have Codex Cage implement it and open
+# a PR. Requires these labels to exist and two secrets (see docs/workflow.md):
+#   - CODEX_CAGE_GITHUB_TOKEN: a PAT or GitHub App token (NOT the default
+#     GITHUB_TOKEN, whose events do not trigger downstream workflows).
+#   - OPENAI_API_KEY: Codex auth for direct-mode runs.
+on:
+  issues:
+    types: [labeled]
+
+# One run per issue; a second label while a run is in flight is queued, not raced.
+concurrency:
+  group: codex-cage-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CODEX_CLI_VERSION: "0.125.0"
+
+jobs:
+  run:
+    if: github.event.label.name == 'codex-cage:run'
+    runs-on: ubuntu-latest
+    env:
+      CODEX_CAGE_EXECUTION: direct
+      GH_TOKEN: ${{ secrets.CODEX_CAGE_GITHUB_TOKEN }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      ISSUE_URL: ${{ github.event.issue.html_url }}
+      RESULT_FILE: ${{ runner.temp }}/result.json
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Mark issue in progress
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --remove-label 'codex-cage:run' \
+            --add-label 'codex-cage:in-progress'
+
+      - name: Check out Codex Cage
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build Codex Cage
+        run: |
+          npm ci
+          npm run build
+
+      - name: Install Codex CLI
+        run: npm install -g "@openai/codex@${CODEX_CLI_VERSION}"
+
+      - name: Write Codex Cage credentials
+        run: |
+          {
+            printf 'OPENAI_API_KEY=%s\n' "${{ secrets.OPENAI_API_KEY }}"
+            printf 'GITHUB_TOKEN=%s\n' "${{ secrets.CODEX_CAGE_GITHUB_TOKEN }}"
+          } > .codex-cage.env
+
+      - name: Run Codex Cage
+        run: node dist/src/cli.js run "$ISSUE_URL" --result-json "$RESULT_FILE"
+
+      - name: Report failure
+        if: failure()
+        run: |
+          FAILURE_CODE=$(jq -r '.failureCode // "unknown"' "$RESULT_FILE" 2>/dev/null || echo unknown)
+          BODY="Codex Cage run failed (\`${FAILURE_CODE}\`). [View workflow run](${RUN_URL})."
+          SUMMARY_FILE=$(ls .codex-cage/runs/*/summary.md 2>/dev/null | head -n1 || true)
+          if [ -n "$SUMMARY_FILE" ]; then
+            BODY="${BODY}"$'\n\n'"$(cat "$SUMMARY_FILE")"
+          fi
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$BODY"
+          gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --add-label 'codex-cage:blocked'
+
+      - name: Upload run artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-cage-run-${{ github.event.issue.number }}
+          path: .codex-cage/runs/
+          if-no-files-found: ignore
+
+      - name: Clear in-progress label
+        if: always()
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --remove-label 'codex-cage:in-progress' || true

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -158,7 +158,7 @@ When a Compose file lives under `.codex-cage/`, Codex Cage still runs Compose wi
 
 ## Execution Modes
 
-> Status: in progress. Tracked in [#80](https://github.com/jhowliu/codex-cage/issues/80). The engine supports both modes; the GitHub Actions workflow that selects direct mode is still pending.
+> Status: in progress. Tracked in [#80](https://github.com/jhowliu/codex-cage/issues/80). The engine supports both modes, and the label-triggered GitHub Actions workflow (see [GitHub Actions Automation](#github-actions-automation)) runs direct mode. A PR-revise loop is still pending.
 
 Select the mode with the `CODEX_CAGE_EXECUTION` environment variable (`docker` or `direct`) or the `execution` key in `.codex-cage.yml`. The environment variable wins; both default to `docker`.
 
@@ -196,6 +196,44 @@ For automation, `codex-cage run` emits a deterministic outcome so a workflow can
   ```
 
   `status` is `succeeded` or `failed`; `failureCode` is `null` on success and a failure code (for example `verify_failed`, `review_blocking`) otherwise; `prUrl` is `null` unless a PR was opened.
+
+## GitHub Actions Automation
+
+`.github/workflows/issue-run.yml` turns an issue label into a direct-mode run. Adding the `codex-cage:run` label to an issue builds Codex Cage, runs it against that issue on the runner, and opens a PR on success.
+
+**Label state machine.** The workflow drives three labels:
+
+- `codex-cage:run` — the trigger. Removed as soon as the run starts.
+- `codex-cage:in-progress` — added at start, removed at the end (success or failure).
+- `codex-cage:blocked` — added on failure, together with a comment that carries the failure code, a link to the workflow run, and the run summary when present.
+
+Create all three labels once before using the workflow. The full run artifact directory is uploaded to each workflow run for debugging.
+
+**Secrets.** Configure two repository secrets:
+
+- `OPENAI_API_KEY` — Codex auth for direct-mode runs.
+- `CODEX_CAGE_GITHUB_TOKEN` — a fine-grained PAT or GitHub App installation token used for clone, push, PR creation, and label/comment updates.
+
+Use `CODEX_CAGE_GITHUB_TOKEN` rather than the built-in `GITHUB_TOKEN`: events produced by the default token (opening a PR, adding a label) do not trigger further workflows, so any downstream automation (for example a future review workflow) would never fire. A PAT or App token is also required for the run to push branches and open PRs. The same token permissions as a local run apply (see [GitHub Token Permissions](#github-token-permissions)), plus **Issues: Read and write** for the label state machine.
+
+**Services (db, redis, …).** The default workflow runs directly on `ubuntu-latest` and installs the Codex CLI, which is enough for repos whose `verify` needs no external services. For a repo that needs services, run the job inside the Codex Cage base image and declare service containers so they resolve by DNS name:
+
+```yaml
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    container: ghcr.io/jhowliu/codex-cage/base:0.1.1
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s --health-retries 10
+```
+
+Inside a job container, service containers share a network and are reachable by service name (`postgres`, `redis`), matching the Compose DNS-name convention used in Docker mode. Service definitions live in the workflow, not in `.codex-cage.yml` (`services.compose` is ignored in direct mode).
 
 ## Prompt Instructions
 


### PR DESCRIPTION
Implements #84 (the final MVP piece of #80). Builds on direct mode (#82) and the CI outcome signal (#83).

## What

`.github/workflows/issue-run.yml` — adding the `codex-cage:run` label to an issue triggers a run:

1. **Mark in progress** — remove `codex-cage:run`, add `codex-cage:in-progress`.
2. **Build & install** — checkout, Node 22, `npm ci && npm run build`, install the pinned Codex CLI.
3. **Run** — write `.codex-cage.env` from secrets, then `node dist/src/cli.js run "$ISSUE_URL" --result-json …` with `CODEX_CAGE_EXECUTION=direct`. On success the engine opens the PR.
4. **On failure** (`if: failure()`) — read `failureCode` from the result file, comment on the issue with the code + workflow-run link (+ run summary if present), and add `codex-cage:blocked`.
5. **Always** — upload the run artifact dir; clear `codex-cage:in-progress`.

Keyed by a per-issue `concurrency` group so re-labelling doesn't race.

**Token.** Uses `CODEX_CAGE_GITHUB_TOKEN` (PAT/App token), not the default `GITHUB_TOKEN`, because default-token events don't trigger downstream workflows and the run needs push/PR rights. `OPENAI_API_KEY` provides Codex auth.

**Supporting changes**
- Root `.codex-cage.yml` (setup `npm ci`, verify `npm test`) so Codex Cage can run against its own issues.
- `docs/workflow.md`: new **GitHub Actions Automation** section — labels, secrets, the token rationale, and the `container:` + `services:` extension for repos needing db/redis (services resolve by DNS name inside a job container, matching the Docker-mode convention).

## Setup required to use it

- Repo secrets: `OPENAI_API_KEY`, `CODEX_CAGE_GITHUB_TOKEN`.
- Labels `codex-cage:run` / `codex-cage:in-progress` / `codex-cage:blocked` (already created in this repo).

## Validation

YAML parses and prettier is clean; existing suite still green (123 tests). End-to-end behavior can only be exercised by labeling a real issue once merged (Actions can't run from this branch's fork context locally).

## Out of scope

PR-revise loop (re-running against review feedback on an existing PR) — needs an "update existing PR" mode in `publish.ts` and a `pull_request_target` workflow; planned as a follow-up PRD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)