### PR TITLE
fix: two direct-mode hangs (stdin + leaked execution-mode env)

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -8,6 +8,7 @@ import {
   parseCodexCageConfig,
   resolveExecutionMode,
   type CodexCageConfig,
+  type ExecutionMode,
 } from "./config.js";
 import { prepareRunCredentials } from "./credentials.js";
 import {
@@ -63,6 +64,9 @@ export type RunCodexCageDependencies = {
   generateRunId?: () => string;
   findCodexAuthFile?: typeof findCodexAuthFile;
   onProgress?: (event: RunProgressEvent) => void;
+  // Overrides mode resolution (env > config > docker). Tests pin this so they
+  // are not influenced by an ambient CODEX_CAGE_EXECUTION.
+  executionMode?: ExecutionMode;
 };
 
 const configPath = ".codex-cage.yml";
@@ -160,10 +164,12 @@ async function prepareRuntimeContext(
     source: "configured" as const,
   };
   const promptContext = await buildPromptContext(cwd);
-  const executionMode = resolveExecutionMode({
-    env: process.env,
-    config: configResult.config,
-  });
+  const executionMode =
+    dependencies.executionMode ??
+    resolveExecutionMode({
+      env: process.env,
+      config: configResult.config,
+    });
 
   return {
     cwd,

--- a/src/sandbox-execution.ts
+++ b/src/sandbox-execution.ts
@@ -91,6 +91,11 @@ export function createHostShellRunner(
           shell: true,
           cwd: workspacePath,
           env: commandEnv,
+          // Close stdin so host commands get EOF immediately. Codex CLI's
+          // `exec` reads stdin and would otherwise hang waiting for input
+          // that never arrives (the Docker runner is immune because the
+          // container has no stdin attached).
+          stdin: "ignore",
           reject: false,
         },
       );

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -16,6 +16,12 @@ import type { ReviewReport, RunIndependentReviewResult } from "../src/review.js"
 import { runCodexCage, type ShellRunner } from "../src/run.js";
 import { openRunStore } from "../src/state.js";
 
+// These tests inject Docker-mode fakes and must stay hermetic. Clear any
+// ambient CODEX_CAGE_EXECUTION (e.g. when the suite itself runs inside a
+// direct-mode Codex Cage run) so resolveExecutionMode does not switch
+// runCodexCage to real host execution and perform real clones / codex calls.
+delete process.env.CODEX_CAGE_EXECUTION;
+
 const repo: GithubRepo = {
   owner: "jhowliu",
   name: "codex-cage",

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -13,14 +13,12 @@ import type { IssueContext } from "../src/issue.js";
 import type { CommandResult, PublishSuccessfulRunInput } from "../src/publish.js";
 import type { GithubRepo, RepoResolution } from "../src/repo.js";
 import type { ReviewReport, RunIndependentReviewResult } from "../src/review.js";
-import { runCodexCage, type ShellRunner } from "../src/run.js";
+import {
+  runCodexCage,
+  type RunCodexCageDependencies,
+  type ShellRunner,
+} from "../src/run.js";
 import { openRunStore } from "../src/state.js";
-
-// These tests inject Docker-mode fakes and must stay hermetic. Clear any
-// ambient CODEX_CAGE_EXECUTION (e.g. when the suite itself runs inside a
-// direct-mode Codex Cage run) so resolveExecutionMode does not switch
-// runCodexCage to real host execution and perform real clones / codex calls.
-delete process.env.CODEX_CAGE_EXECUTION;
 
 const repo: GithubRepo = {
   owner: "jhowliu",
@@ -114,6 +112,114 @@ function passingReview(): RunIndependentReviewResult {
   };
 }
 
+// Shell that satisfies the happy path in both execution modes. Docker mode
+// clones via the fake sandbox, direct mode clones via the shell, so this
+// includes both `git clone` and `git fetch`.
+function happyPathShell(): ReturnType<typeof shellRunner> {
+  return shellRunner(
+    new Map([
+      ["git clone", commandResult()],
+      ["git fetch origin", commandResult()],
+      ["npm install", commandResult("setup passed")],
+      ["codex exec", commandResult("implemented")],
+      ["npm test", commandResult("tests passed")],
+      [
+        "git add --intent-to-add",
+        commandResult(`diff --git a/src/app.ts b/src/app.ts
+@@ -1 +1,2 @@
+ export const ok = true;
++export const changed = true;
+`),
+      ],
+    ]),
+  );
+}
+
+// Mode-specific provisioning fakes. Direct mode must never touch Docker; Docker
+// mode must never touch the host workspace.
+function modeDeps(
+  mode: "docker" | "direct",
+  shell: ShellRunner,
+  events: string[],
+): RunCodexCageDependencies {
+  if (mode === "direct") {
+    return {
+      executionMode: "direct",
+      createDockerSandbox: () => {
+        throw new Error("Docker sandbox must not be created in direct mode.");
+      },
+      createHostWorkspace: async () => ({
+        workspacePath: "/tmp/codex-cage-happy",
+        cleanup: async () => undefined,
+      }),
+      createHostShellRunner: () => shell,
+    };
+  }
+
+  return {
+    executionMode: "docker",
+    createHostWorkspace: () => {
+      throw new Error("Host workspace must not be created in docker mode.");
+    },
+    createDockerSandbox: () => fakeSandbox(events),
+    createShellRunner: () => shell,
+  };
+}
+
+for (const mode of ["docker", "direct"] as const) {
+  test(`runCodexCage reaches every gate and opens a PR in ${mode} mode`, async () => {
+    const cwd = await createProject(`
+setup:
+  - npm install
+verify:
+  - npm test
+`);
+    const events: string[] = [];
+    const shell = happyPathShell();
+
+    try {
+      const result = await runCodexCage(
+        { cwd, issueUrl: issue.url },
+        {
+          generateRunId: () => `run-happy-${mode}`,
+          readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
+          findCodexAuthFile: async () => null,
+          fetchIssueContext: async () => issue,
+          resolveTargetRepo: async () => repoResolution,
+          createAuthenticatedRepo: () => ({
+            repo,
+            cloneUrl: "https://github.com/jhowliu/codex-cage.git",
+            redactedCloneUrl: "https://github.com/jhowliu/codex-cage.git",
+          }),
+          runIndependentReview: async () => passingReview(),
+          publishSuccessfulRun: async (input) => ({
+            branchName: input.branchName ?? `codex-cage/gh-26-${mode}`,
+            commitMessage: "#26 Wire run command",
+            prTitle: "#26 Wire run command",
+            prBody: "body",
+            prUrl: "https://github.com/jhowliu/codex-cage/pull/26",
+          }),
+          ...modeDeps(mode, shell, events),
+        },
+      );
+
+      // Engine outcome is mode-agnostic: same status, PR, and phase sequence.
+      assert.equal(result.status, "succeeded");
+      assert.equal(result.prUrl, "https://github.com/jhowliu/codex-cage/pull/26");
+
+      const store = await openRunStore(cwd);
+      const details = store.getRunDetails(`run-happy-${mode}`);
+      store.close();
+      assert.deepEqual(
+        details.phases.map((phase) => phase.name),
+        ["preflight", "cloning", "setup", "implement", "verify", "review", "pr"],
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+}
+
 test("runCodexCage parses review agent stdout without command log noise", async () => {
   const cwd = await createProject(`
 verify:
@@ -147,6 +253,7 @@ verify:
         issueUrl: issue.url,
       },
       {
+        executionMode: "docker",
         generateRunId: () => "run-review-stdout",
         readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
         findCodexAuthFile: async () => null,
@@ -253,6 +360,7 @@ verify:
         issueUrl: issue.url,
       },
       {
+        executionMode: "docker",
         generateRunId: () => "run-test-123",
         readEnv: async () => ({
           GITHUB_TOKEN: "token-value",
@@ -413,7 +521,6 @@ verify:
 
 test("runCodexCage runs direct mode on the host without Docker resources", async () => {
   const cwd = await createProject(`
-execution: direct
 setup:
   - npm install
 verify:
@@ -452,6 +559,7 @@ services:
         issueUrl: issue.url,
       },
       {
+        executionMode: "direct",
         generateRunId: () => "run-direct-1",
         readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
         findCodexAuthFile: async () => null,
@@ -553,6 +661,7 @@ verify:
         issueUrl: issue.url,
       },
       {
+        executionMode: "docker",
         generateRunId: () => "run-publish-redact",
         readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
         findCodexAuthFile: async () => null,
@@ -625,6 +734,7 @@ runtime:
         issueUrl: issue.url,
       },
       {
+        executionMode: "docker",
         generateRunId: () => "run-image-123",
         readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
         findCodexAuthFile: async () => null,
@@ -703,6 +813,7 @@ runtime:
         issueUrl: issue.url,
       },
       {
+        executionMode: "docker",
         generateRunId: () => "run-image-failed",
         readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
         findCodexAuthFile: async () => null,
@@ -766,6 +877,7 @@ agent:
         issueUrl: issue.url,
       },
       {
+        executionMode: "docker",
         generateRunId: () => "run-test-failed",
         readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
         findCodexAuthFile: async () => null,

--- a/test/sandbox-execution.test.ts
+++ b/test/sandbox-execution.test.ts
@@ -61,6 +61,19 @@ test("host shell runner supports shell operators like the docker runner", async 
   });
 });
 
+test("host shell runner closes stdin so stdin-reading commands do not hang", async () => {
+  await withWorkspace(async (workspacePath) => {
+    const runner = createHostShellRunner(workspacePath);
+
+    // `cat` with no file reads stdin until EOF. With stdin closed it returns
+    // immediately; without the fix this would hang forever.
+    const result = await runner.run("cat");
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, "");
+  });
+});
+
 test("host shell runner configures git askpass when a GitHub token is present", async () => {
   await withWorkspace(async (workspacePath) => {
     const runner = createHostShellRunner(workspacePath, {


### PR DESCRIPTION
Two independent bugs that make **direct-mode** runs hang, both found while smoke-testing the issue-label workflow (#84). Docker mode was unaffected by either.

## Bug 1 — host runner leaves stdin open → `codex exec` hangs

Codex CLI's `exec` reads stdin (`Reading additional input from stdin...`). The direct-mode host shell runner ran commands via execa with stdin open, so `codex exec` blocked forever waiting for input. The Docker runner is immune because `docker run` (no `-i`) gives the container no stdin.

**Fix:** pass `stdin: "ignore"` to the host runner's execa call.
**Test:** `runner.run("cat")` (cat reads stdin to EOF) now returns instead of hanging.

## Bug 2 — leaked `CODEX_CAGE_EXECUTION` flips the test suite to real host execution → verify hangs

`test/run.test.ts` injects Docker-mode fakes, but `runCodexCage` resolved the execution mode from `process.env`. When the suite runs **inside** a direct-mode Codex Cage run — e.g. a self-hosted run whose `verify` is `npm test` — the ambient `CODEX_CAGE_EXECUTION=direct` leaked in, switching those tests to **real host execution** (real `git clone`, real `codex exec`), hanging the verify phase for minutes. This is exactly the "internal_error / missing pr.log" failures Codex itself reported.

Reproduced: `CODEX_CAGE_EXECUTION=direct npm test` hangs on a clean clone; without it, 123 pass in ~1s.

**Fix:** make the execution mode an injectable dependency of `runCodexCage` (`dependencies.executionMode ?? resolveExecutionMode(env, config)`). Each orchestration test now pins its mode explicitly, so the suite is hermetic by construction — no global env mutation. Production resolution (env > config > docker) is unchanged.

**Tests:** the happy path is now **parameterized over both docker and direct modes**, asserting the mode-agnostic engine outcome (status, prUrl, phase sequence); each mode also asserts the other mode's provisioning is never touched. Verified: `CODEX_CAGE_EXECUTION=direct npm test` now finishes (126 pass).

This matters for **self-hosting** — the #84 workflow sets `CODEX_CAGE_EXECUTION=direct` and runs `npm test` as verify, so every self-hosted run would otherwise hang.

## Result

Full suite green (126), passes both with and without `CODEX_CAGE_EXECUTION=direct`. Prettier clean.

## Follow-ups worth filing (not in this PR)

- `timeouts` config is parsed but never enforced (no execa timeout / AbortController) — a hung command never self-aborts; also add `timeout-minutes` to the workflow.
- Codex inherits `model_reasoning_effort` (e.g. `xhigh`) from `~/.codex/config.toml`, making runs very slow; Codex Cage may want to pin/expose it.
- Pre-run errors (auth/issue-fetch, e.g. a 401) throw out of `prepareRuntimeContext`, bypassing the `RunCodexCageResult` / `--result-json` / exit-code path.
- Direct-mode command output is buffered (no live stream), so long phases look frozen in CI and locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)