### PR TITLE
feat: --verbose live redacted output streaming

### DIFF
--- a/.github/workflows/issue-run.yml
+++ b/.github/workflows/issue-run.yml
@@ -61,7 +61,7 @@ jobs:
           } > .codex-cage.env
 
       - name: Run Codex Cage
-        run: node dist/src/cli.js run "$ISSUE_URL" --result-json "$RUNNER_TEMP/result.json"
+        run: node dist/src/cli.js run "$ISSUE_URL" --verbose --result-json "$RUNNER_TEMP/result.json"
 
       - name: Report failure
         if: failure()

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,6 +8,7 @@ import { openRunStore } from "./state.js";
 import { readPackageVersion } from "./version.js";
 
 export const RESULT_FILE_ENV = "CODEX_CAGE_RESULT_FILE";
+export const VERBOSE_ENV = "CODEX_CAGE_VERBOSE";
 
 export type CliDependencies = {
   runCodexCage?: typeof runCodexCage;
@@ -54,6 +55,10 @@ export function createCli(dependencies: CliDependencies = {}): Command {
       "--result-json <path>",
       `write the machine-readable run result to <path> (also settable via ${RESULT_FILE_ENV})`,
     )
+    .option(
+      "--verbose",
+      `stream redacted command output live to stdout (also settable via ${VERBOSE_ENV})`,
+    )
     .action(
       async (
         issueArgument: string | undefined,
@@ -64,6 +69,7 @@ export function createCli(dependencies: CliDependencies = {}): Command {
           model?: string;
           draft?: boolean;
           resultJson?: string;
+          verbose?: boolean;
         },
         command: Command,
       ) => {
@@ -75,6 +81,7 @@ export function createCli(dependencies: CliDependencies = {}): Command {
           command.error("error: missing required issue URL");
         }
 
+        const verbose = options.verbose === true || process.env[VERBOSE_ENV] === "1";
         const result = await run(
           removeUndefinedProperties({
             issueUrl,
@@ -82,6 +89,7 @@ export function createCli(dependencies: CliDependencies = {}): Command {
             base: options.base,
             model: options.model,
             draft: options.draft,
+            verbose: verbose ? true : undefined,
           }),
           {
             onProgress: (event) => {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -31,6 +31,8 @@ export type DockerSandboxOptions = {
 export type DockerCommandOptions = {
   env?: Record<string, string>;
   codexAuthFilePath?: string | undefined;
+  // Live output sink: receives stdout/stderr chunks as the command runs.
+  onData?: ((chunk: string) => void) | undefined;
 };
 
 export type DockerSandbox = {

--- a/src/run-workflow.ts
+++ b/src/run-workflow.ts
@@ -34,12 +34,14 @@ import {
   createDockerShellRunner,
   createHostShellRunner,
   createHostWorkspace,
+  createLineStreamSink,
   formatCommandLog,
   readCurrentDiff,
   requiredShell,
   shellQuote,
   type HostWorkspace,
   type ShellRunner,
+  type StreamSink,
 } from "./sandbox-execution.js";
 import type { FailureCode, PhaseName, RunStore } from "./state.js";
 
@@ -98,6 +100,7 @@ export type RuntimeContext = {
   runtimeImage: RuntimeImageBuildResult & { source: "configured" | "built" };
   promptContext: PromptContext;
   executionMode: ExecutionMode;
+  verbose: boolean;
 };
 
 export type RunWorkflowInput = {
@@ -108,6 +111,7 @@ export type RunWorkflowInput = {
   createShellRunner?: (
     sandbox: DockerSandbox,
     env: Record<string, string>,
+    sink?: StreamSink,
   ) => ShellRunner;
   createHostWorkspace?: typeof createHostWorkspace;
   createHostShellRunner?: typeof createHostShellRunner;
@@ -130,6 +134,11 @@ export async function runWorkflow(input: RunWorkflowInput): Promise<RunCodexCage
   const onProgress = input.onProgress ?? (() => undefined);
   const journal = new RunJournal(input.store, context, onProgress);
   const redactor = context.credentials.redactor();
+  // In verbose mode, stream redacted command output to stdout so progress is
+  // visible live (locally and, crucially, in CI logs where files are not).
+  const streamSink = context.verbose
+    ? createLineStreamSink((line) => process.stdout.write(line), redactor)
+    : undefined;
   let sandbox: DockerSandbox | null = null;
   let shell: ShellRunner | null = null;
   let compose: ComposeProject | null = null;
@@ -160,6 +169,7 @@ export async function runWorkflow(input: RunWorkflowInput): Promise<RunCodexCage
         context,
         journal,
         redactor,
+        sink: streamSink,
         createHostWorkspace: makeHostWorkspace,
         createHostShellRunner: makeHostShellRunner,
         registerWorkspace: (workspace) => {
@@ -171,6 +181,7 @@ export async function runWorkflow(input: RunWorkflowInput): Promise<RunCodexCage
         context,
         journal,
         redactor,
+        sink: streamSink,
         createSandbox,
         buildImage,
         makeShellRunner,
@@ -252,9 +263,14 @@ async function provisionDockerSandbox(input: {
   context: RuntimeContext;
   journal: RunJournal;
   redactor: (value: string) => string;
+  sink: StreamSink | undefined;
   createSandbox: (options: DockerSandboxOptions) => DockerSandbox;
   buildImage: typeof buildRuntimeImage;
-  makeShellRunner: (sandbox: DockerSandbox, env: Record<string, string>) => ShellRunner;
+  makeShellRunner: (
+    sandbox: DockerSandbox,
+    env: Record<string, string>,
+    sink?: StreamSink,
+  ) => ShellRunner;
   makeComposeProject: typeof createComposeProject;
   registerCompose: (project: ComposeProject) => void;
   registerSandbox: (sandbox: DockerSandbox) => void;
@@ -328,7 +344,7 @@ async function provisionDockerSandbox(input: {
 
   const sandbox = input.createSandbox(sandboxOptions);
   input.registerSandbox(sandbox);
-  const shell = input.makeShellRunner(sandbox, {});
+  const shell = input.makeShellRunner(sandbox, {}, input.sink);
 
   await journal.setRunStatus("cloning");
   await journal.runPhase("cloning", async () => {
@@ -351,6 +367,7 @@ async function provisionDirectWorkspace(input: {
   context: RuntimeContext;
   journal: RunJournal;
   redactor: (value: string) => string;
+  sink: StreamSink | undefined;
   createHostWorkspace: typeof createHostWorkspace;
   createHostShellRunner: typeof createHostShellRunner;
   registerWorkspace: (workspace: HostWorkspace) => void;
@@ -362,7 +379,7 @@ async function provisionDirectWorkspace(input: {
   const cloneCredentials = runtimeCommandCredentials("clone", context);
   const workspace = await input.createHostWorkspace(context.runId);
   input.registerWorkspace(workspace);
-  const shell = input.createHostShellRunner(workspace.workspacePath, {});
+  const shell = input.createHostShellRunner(workspace.workspacePath, {}, input.sink);
 
   await journal.setRunStatus("cloning");
   await journal.runPhase("cloning", async () => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -42,6 +42,7 @@ export type RunCommandOptions = {
   base?: string | undefined;
   model?: string | undefined;
   draft?: boolean | undefined;
+  verbose?: boolean | undefined;
 };
 
 export type RunCodexCageDependencies = {
@@ -187,6 +188,7 @@ async function prepareRuntimeContext(
     runtimeImage,
     promptContext,
     executionMode,
+    verbose: options.verbose ?? false,
   };
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -8,6 +8,7 @@ import {
   parseCodexCageConfig,
   resolveExecutionMode,
   type CodexCageConfig,
+  type ExecutionMode,
 } from "./config.js";
 import { prepareRunCredentials } from "./credentials.js";
 import {
@@ -63,6 +64,9 @@ export type RunCodexCageDependencies = {
   generateRunId?: () => string;
   findCodexAuthFile?: typeof findCodexAuthFile;
   onProgress?: (event: RunProgressEvent) => void;
+  // Overrides mode resolution (env > config > docker). Tests pin this so they
+  // are not influenced by an ambient CODEX_CAGE_EXECUTION.
+  executionMode?: ExecutionMode;
 };
 
 const configPath = ".codex-cage.yml";
@@ -160,10 +164,12 @@ async function prepareRuntimeContext(
     source: "configured" as const,
   };
   const promptContext = await buildPromptContext(cwd);
-  const executionMode = resolveExecutionMode({
-    env: process.env,
-    config: configResult.config,
-  });
+  const executionMode =
+    dependencies.executionMode ??
+    resolveExecutionMode({
+      env: process.env,
+      config: configResult.config,
+    });
 
   return {
     cwd,

--- a/src/sandbox-execution.ts
+++ b/src/sandbox-execution.ts
@@ -2,6 +2,7 @@ import { execa } from "execa";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Writable } from "node:stream";
 import {
   commandWithGitHubAuth,
   dockerRunArgs,
@@ -14,6 +15,61 @@ import type { ReviewAgentRunner } from "./review.js";
 export type ShellRunner = {
   run(command: string, options?: DockerCommandOptions): Promise<CommandResult>;
 };
+
+// A line-buffered output sink. Chunks are accumulated and each complete line is
+// passed through `redact` before `write`, so secrets are removed even when the
+// output streams live. Callers flush after a command to emit a trailing
+// partial line.
+export type StreamSink = {
+  onData: (chunk: string) => void;
+  flush: () => void;
+};
+
+export function createLineStreamSink(
+  write: (line: string) => void,
+  redact: (input: string) => string = (input) => input,
+): StreamSink {
+  let buffer = "";
+  const emit = (line: string): void => write(redact(line));
+
+  return {
+    onData(chunk: string): void {
+      buffer += chunk;
+      let index = buffer.indexOf("\n");
+      while (index !== -1) {
+        emit(buffer.slice(0, index + 1));
+        buffer = buffer.slice(index + 1);
+        index = buffer.indexOf("\n");
+      }
+    },
+    flush(): void {
+      if (buffer.length > 0) {
+        emit(buffer.endsWith("\n") ? buffer : `${buffer}\n`);
+        buffer = "";
+      }
+    },
+  };
+}
+
+// Builds execa stdio options that both buffer output (for the returned result)
+// and tee live chunks to `onData`. Without a sink, execa keeps its defaults.
+function outputTeeOptions(
+  onData: ((chunk: string) => void) | undefined,
+): { stdout: ["pipe", Writable]; stderr: ["pipe", Writable] } | Record<string, never> {
+  if (onData === undefined) {
+    return {};
+  }
+
+  const sink = (): Writable =>
+    new Writable({
+      write(chunk, _encoding, callback): void {
+        onData(chunk.toString());
+        callback();
+      },
+    });
+
+  return { stdout: ["pipe", sink()], stderr: ["pipe", sink()] };
+}
 
 export type HostWorkspace = {
   workspacePath: string;
@@ -38,6 +94,7 @@ export async function createHostWorkspace(runId: string): Promise<HostWorkspace>
 export function createDockerShellRunner(
   sandbox: DockerSandbox,
   _env: Record<string, string>,
+  sink?: StreamSink,
 ): ShellRunner {
   return {
     async run(
@@ -45,6 +102,7 @@ export function createDockerShellRunner(
       options: DockerCommandOptions = {},
     ): Promise<CommandResult> {
       const commandEnv = options.env ?? {};
+      const onData = options.onData ?? sink?.onData;
       const result = await execa(
         "docker",
         dockerRunArgs({
@@ -60,8 +118,10 @@ export function createDockerShellRunner(
         {
           env: commandEnv,
           reject: false,
+          ...outputTeeOptions(onData),
         },
       );
+      sink?.flush();
 
       return {
         exitCode: result.exitCode ?? 0,
@@ -75,6 +135,7 @@ export function createDockerShellRunner(
 export function createHostShellRunner(
   workspacePath: string,
   env: Record<string, string> = {},
+  sink?: StreamSink,
 ): ShellRunner {
   return {
     async run(
@@ -82,6 +143,7 @@ export function createHostShellRunner(
       options: DockerCommandOptions = {},
     ): Promise<CommandResult> {
       const commandEnv = { ...env, ...(options.env ?? {}) };
+      const onData = options.onData ?? sink?.onData;
       const result = await execa(
         commandWithGitHubAuth(
           hostCommandWithCodexAuth(command, options.codexAuthFilePath),
@@ -97,8 +159,10 @@ export function createHostShellRunner(
           // container has no stdin attached).
           stdin: "ignore",
           reject: false,
+          ...outputTeeOptions(onData),
         },
       );
+      sink?.flush();
 
       return {
         exitCode: result.exitCode ?? 0,

--- a/src/sandbox-execution.ts
+++ b/src/sandbox-execution.ts
@@ -91,6 +91,11 @@ export function createHostShellRunner(
           shell: true,
           cwd: workspacePath,
           env: commandEnv,
+          // Close stdin so host commands get EOF immediately. Codex CLI's
+          // `exec` reads stdin and would otherwise hang waiting for input
+          // that never arrives (the Docker runner is immune because the
+          // container has no stdin attached).
+          stdin: "ignore",
           reject: false,
         },
       );

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -16,6 +16,12 @@ import type { ReviewReport, RunIndependentReviewResult } from "../src/review.js"
 import { runCodexCage, type ShellRunner } from "../src/run.js";
 import { openRunStore } from "../src/state.js";
 
+// These tests inject Docker-mode fakes and must stay hermetic. Clear any
+// ambient CODEX_CAGE_EXECUTION (e.g. when the suite itself runs inside a
+// direct-mode Codex Cage run) so resolveExecutionMode does not switch
+// runCodexCage to real host execution and perform real clones / codex calls.
+delete process.env.CODEX_CAGE_EXECUTION;
+
 const repo: GithubRepo = {
   owner: "jhowliu",
   name: "codex-cage",

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -13,14 +13,12 @@ import type { IssueContext } from "../src/issue.js";
 import type { CommandResult, PublishSuccessfulRunInput } from "../src/publish.js";
 import type { GithubRepo, RepoResolution } from "../src/repo.js";
 import type { ReviewReport, RunIndependentReviewResult } from "../src/review.js";
-import { runCodexCage, type ShellRunner } from "../src/run.js";
+import {
+  runCodexCage,
+  type RunCodexCageDependencies,
+  type ShellRunner,
+} from "../src/run.js";
 import { openRunStore } from "../src/state.js";
-
-// These tests inject Docker-mode fakes and must stay hermetic. Clear any
-// ambient CODEX_CAGE_EXECUTION (e.g. when the suite itself runs inside a
-// direct-mode Codex Cage run) so resolveExecutionMode does not switch
-// runCodexCage to real host execution and perform real clones / codex calls.
-delete process.env.CODEX_CAGE_EXECUTION;
 
 const repo: GithubRepo = {
   owner: "jhowliu",
@@ -114,6 +112,114 @@ function passingReview(): RunIndependentReviewResult {
   };
 }
 
+// Shell that satisfies the happy path in both execution modes. Docker mode
+// clones via the fake sandbox, direct mode clones via the shell, so this
+// includes both `git clone` and `git fetch`.
+function happyPathShell(): ReturnType<typeof shellRunner> {
+  return shellRunner(
+    new Map([
+      ["git clone", commandResult()],
+      ["git fetch origin", commandResult()],
+      ["npm install", commandResult("setup passed")],
+      ["codex exec", commandResult("implemented")],
+      ["npm test", commandResult("tests passed")],
+      [
+        "git add --intent-to-add",
+        commandResult(`diff --git a/src/app.ts b/src/app.ts
+@@ -1 +1,2 @@
+ export const ok = true;
++export const changed = true;
+`),
+      ],
+    ]),
+  );
+}
+
+// Mode-specific provisioning fakes. Direct mode must never touch Docker; Docker
+// mode must never touch the host workspace.
+function modeDeps(
+  mode: "docker" | "direct",
+  shell: ShellRunner,
+  events: string[],
+): RunCodexCageDependencies {
+  if (mode === "direct") {
+    return {
+      executionMode: "direct",
+      createDockerSandbox: () => {
+        throw new Error("Docker sandbox must not be created in direct mode.");
+      },
+      createHostWorkspace: async () => ({
+        workspacePath: "/tmp/codex-cage-happy",
+        cleanup: async () => undefined,
+      }),
+      createHostShellRunner: () => shell,
+    };
+  }
+
+  return {
+    executionMode: "docker",
+    createHostWorkspace: () => {
+      throw new Error("Host workspace must not be created in docker mode.");
+    },
+    createDockerSandbox: () => fakeSandbox(events),
+    createShellRunner: () => shell,
+  };
+}
+
+for (const mode of ["docker", "direct"] as const) {
+  test(`runCodexCage reaches every gate and opens a PR in ${mode} mode`, async () => {
+    const cwd = await createProject(`
+setup:
+  - npm install
+verify:
+  - npm test
+`);
+    const events: string[] = [];
+    const shell = happyPathShell();
+
+    try {
+      const result = await runCodexCage(
+        { cwd, issueUrl: issue.url },
+        {
+          generateRunId: () => `run-happy-${mode}`,
+          readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
+          findCodexAuthFile: async () => null,
+          fetchIssueContext: async () => issue,
+          resolveTargetRepo: async () => repoResolution,
+          createAuthenticatedRepo: () => ({
+            repo,
+            cloneUrl: "https://github.com/jhowliu/codex-cage.git",
+            redactedCloneUrl: "https://github.com/jhowliu/codex-cage.git",
+          }),
+          runIndependentReview: async () => passingReview(),
+          publishSuccessfulRun: async (input) => ({
+            branchName: input.branchName ?? `codex-cage/gh-26-${mode}`,
+            commitMessage: "#26 Wire run command",
+            prTitle: "#26 Wire run command",
+            prBody: "body",
+            prUrl: "https://github.com/jhowliu/codex-cage/pull/26",
+          }),
+          ...modeDeps(mode, shell, events),
+        },
+      );
+
+      // Engine outcome is mode-agnostic: same status, PR, and phase sequence.
+      assert.equal(result.status, "succeeded");
+      assert.equal(result.prUrl, "https://github.com/jhowliu/codex-cage/pull/26");
+
+      const store = await openRunStore(cwd);
+      const details = store.getRunDetails(`run-happy-${mode}`);
+      store.close();
+      assert.deepEqual(
+        details.phases.map((phase) => phase.name),
+        ["preflight", "cloning", "setup", "implement", "verify", "review", "pr"],
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+}
+
 test("runCodexCage parses review agent stdout without command log noise", async () => {
   const cwd = await createProject(`
 verify:
@@ -147,6 +253,7 @@ verify:
         issueUrl: issue.url,
       },
       {
+        executionMode: "docker",
         generateRunId: () => "run-review-stdout",
         readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
         findCodexAuthFile: async () => null,
@@ -253,6 +360,7 @@ verify:
         issueUrl: issue.url,
       },
       {
+        executionMode: "docker",
         generateRunId: () => "run-test-123",
         readEnv: async () => ({
           GITHUB_TOKEN: "token-value",
@@ -413,7 +521,6 @@ verify:
 
 test("runCodexCage runs direct mode on the host without Docker resources", async () => {
   const cwd = await createProject(`
-execution: direct
 setup:
   - npm install
 verify:
@@ -452,6 +559,7 @@ services:
         issueUrl: issue.url,
       },
       {
+        executionMode: "direct",
         generateRunId: () => "run-direct-1",
         readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
         findCodexAuthFile: async () => null,
@@ -553,6 +661,7 @@ verify:
         issueUrl: issue.url,
       },
       {
+        executionMode: "docker",
         generateRunId: () => "run-publish-redact",
         readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
         findCodexAuthFile: async () => null,
@@ -625,6 +734,7 @@ runtime:
         issueUrl: issue.url,
       },
       {
+        executionMode: "docker",
         generateRunId: () => "run-image-123",
         readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
         findCodexAuthFile: async () => null,
@@ -703,6 +813,7 @@ runtime:
         issueUrl: issue.url,
       },
       {
+        executionMode: "docker",
         generateRunId: () => "run-image-failed",
         readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
         findCodexAuthFile: async () => null,
@@ -766,6 +877,7 @@ agent:
         issueUrl: issue.url,
       },
       {
+        executionMode: "docker",
         generateRunId: () => "run-test-failed",
         readEnv: async () => ({ GITHUB_TOKEN: "token-value" }),
         findCodexAuthFile: async () => null,

--- a/test/sandbox-execution.test.ts
+++ b/test/sandbox-execution.test.ts
@@ -61,6 +61,19 @@ test("host shell runner supports shell operators like the docker runner", async 
   });
 });
 
+test("host shell runner closes stdin so stdin-reading commands do not hang", async () => {
+  await withWorkspace(async (workspacePath) => {
+    const runner = createHostShellRunner(workspacePath);
+
+    // `cat` with no file reads stdin until EOF. With stdin closed it returns
+    // immediately; without the fix this would hang forever.
+    const result = await runner.run("cat");
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, "");
+  });
+});
+
 test("host shell runner configures git askpass when a GitHub token is present", async () => {
   await withWorkspace(async (workspacePath) => {
     const runner = createHostShellRunner(workspacePath, {

--- a/test/sandbox-execution.test.ts
+++ b/test/sandbox-execution.test.ts
@@ -3,7 +3,11 @@ import { mkdtemp, readdir, realpath, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { createHostShellRunner, createHostWorkspace } from "../src/sandbox-execution.js";
+import {
+  createHostShellRunner,
+  createHostWorkspace,
+  createLineStreamSink,
+} from "../src/sandbox-execution.js";
 
 async function withWorkspace(
   fn: (workspacePath: string) => Promise<void>,
@@ -95,6 +99,37 @@ test("host shell runner leaves git askpass unset without a GitHub token", async 
 
     assert.equal(result.exitCode, 0);
     assert.equal(result.stdout, "unset");
+  });
+});
+
+test("line stream sink redacts complete lines and flushes the remainder", () => {
+  const lines: string[] = [];
+  const sink = createLineStreamSink(
+    (line) => lines.push(line),
+    (input) => input.replaceAll("hunter2", "[REDACTED]"),
+  );
+
+  sink.onData("token=");
+  sink.onData("hunter2\npartial");
+  assert.deepEqual(lines, ["token=[REDACTED]\n"]);
+
+  sink.flush();
+  assert.deepEqual(lines, ["token=[REDACTED]\n", "partial\n"]);
+});
+
+test("host shell runner streams live output while still buffering the result", async () => {
+  await withWorkspace(async (workspacePath) => {
+    const streamed: string[] = [];
+    const sink = createLineStreamSink((line) => streamed.push(line));
+    const runner = createHostShellRunner(workspacePath, {}, sink);
+
+    const result = await runner.run("printf 'a\\nb\\n'");
+
+    // Buffered result is still available (needed for diff/review parsing).
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, "a\nb");
+    // ...and the same output was streamed live, line-buffered.
+    assert.equal(streamed.join(""), "a\nb\n");
   });
 });
 


### PR DESCRIPTION
Stacked on #90. Delivers the **stdout sink** half of the streaming-logs design so you can tell whether a run is progressing or stuck — on both a local terminal and a CI runner.

## Problem

Command output was buffered by the shell runner and only written to the phase log **when the phase finished**. During `codex exec` / `npm test` the console was silent, so long phases looked frozen (this caused several "假卡死" false alarms). On a runner it's worse: a log **file** isn't visible live — only the step's stdout shows in the Actions UI in real time.

## What

- **Shell runners tee output to an optional sink** (`stdout: ['pipe', sink]`) while **still buffering** `result.stdout`/`stderr` — verified by test, so diff/review parsing is unaffected.
- **`createLineStreamSink`** buffers by line and runs each complete line through the redactor before emitting, so **secrets are removed even while streaming**.
- **`--verbose`** (or `CODEX_CAGE_VERBOSE=1`) streams the redacted output to **stdout** — live locally and in CI logs.
- The **issue-run workflow** now runs with `--verbose`, so self-hosted runs are observable in the Actions log.

Redaction is on the streamed path too, so it is safe for shared CI logs (never stream raw).

## Tests

- `createLineStreamSink` redacts complete lines and flushes the trailing partial.
- Host runner with a sink streams live **and** still returns the buffered result (the key guarantee for downstream parsing).
- Full suite green (128).

## Scope / follow-up

This is the **stdout sink**. The **per-phase file sink** (create the log at phase start + line-buffered append, so `tail -f` works locally and killed runs leave partial logs) is a separate increment — it needs the journal to stop overwriting the log at phase end. I can do it next.

Also still open (unchanged from #90's list): enforce `timeouts` + `timeout-minutes`; pin/expose `model_reasoning_effort`; graceful pre-run error handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)