### PR TITLE
fix: use the OpenAI API key for codex when one is provided

### DIFF
--- a/src/docker.ts
+++ b/src/docker.ts
@@ -381,7 +381,7 @@ export function dockerRunArgs(input: DockerRunArgsInput): string[] {
 
 function commandWithAuth(command: string, input: DockerRunArgsInput): string {
   return commandWithGitHubAuth(
-    commandWithCodexAuth(command, input.codexAuthFilePath),
+    commandWithCodexAuth(command, input.codexAuthFilePath, input.env),
     input.env,
   );
 }
@@ -400,18 +400,34 @@ function codexAuthMountArgs(codexAuthFilePath: string | undefined): string[] {
 function commandWithCodexAuth(
   command: string,
   codexAuthFilePath: string | undefined,
+  env: Record<string, string>,
 ): string {
-  if (codexAuthFilePath === undefined) {
+  const hasApiKey = env.OPENAI_API_KEY !== undefined;
+
+  if (!hasApiKey && codexAuthFilePath === undefined) {
     return command;
   }
 
-  return [
-    'if [ -f /tmp/codex-auth.json ] && [ -z "${OPENAI_API_KEY:-}" ]; then mkdir -p /home/agent/.codex',
-    "cp /tmp/codex-auth.json /home/agent/.codex/auth.json",
-    "chmod 600 /home/agent/.codex/auth.json",
-    "fi",
-    command,
-  ].join("; ");
+  const lines: string[] = [];
+
+  if (hasApiKey) {
+    // Log Codex in with the API key into an isolated CODEX_HOME so it uses the
+    // key instead of a ChatGPT/OAuth login, and does not touch the real config.
+    lines.push(
+      'CODEX_HOME="$(mktemp -d)"; export CODEX_HOME',
+      'printf %s "$OPENAI_API_KEY" | codex login --with-api-key >/dev/null 2>&1 || true',
+    );
+  } else if (codexAuthFilePath !== undefined) {
+    lines.push(
+      "if [ -f /tmp/codex-auth.json ]; then mkdir -p /home/agent/.codex",
+      "cp /tmp/codex-auth.json /home/agent/.codex/auth.json",
+      "chmod 600 /home/agent/.codex/auth.json",
+      "fi",
+    );
+  }
+
+  lines.push(command);
+  return lines.join("; ");
 }
 
 export function commandWithGitHubAuth(

--- a/src/sandbox-execution.ts
+++ b/src/sandbox-execution.ts
@@ -146,7 +146,7 @@ export function createHostShellRunner(
       const onData = options.onData ?? sink?.onData;
       const result = await execa(
         commandWithGitHubAuth(
-          hostCommandWithCodexAuth(command, options.codexAuthFilePath),
+          hostCommandWithCodexAuth(command, options.codexAuthFilePath, commandEnv),
           commandEnv,
         ),
         {
@@ -281,22 +281,39 @@ export function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
-function hostCommandWithCodexAuth(
+export function hostCommandWithCodexAuth(
   command: string,
   codexAuthFilePath: string | undefined,
+  env: Record<string, string>,
 ): string {
-  if (codexAuthFilePath === undefined) {
+  const hasApiKey = env.OPENAI_API_KEY !== undefined;
+
+  if (!hasApiKey && codexAuthFilePath === undefined) {
     return command;
   }
 
-  const quoted = shellQuote(codexAuthFilePath);
-  return [
-    `if [ -f ${quoted} ] && [ -z "\${OPENAI_API_KEY:-}" ]; then mkdir -p "\${CODEX_HOME:-$HOME/.codex}"`,
-    `cp ${quoted} "\${CODEX_HOME:-$HOME/.codex}/auth.json"`,
-    `chmod 600 "\${CODEX_HOME:-$HOME/.codex}/auth.json"`,
-    "fi",
-    command,
-  ].join("; ");
+  const lines: string[] = [];
+
+  if (hasApiKey) {
+    // Log Codex in with the API key into an isolated CODEX_HOME so it uses the
+    // key instead of any ChatGPT/OAuth login, without touching the user's
+    // ~/.codex (config and MCP servers are skipped too, keeping runs clean).
+    lines.push(
+      'CODEX_HOME="$(mktemp -d)"; export CODEX_HOME',
+      'printf %s "$OPENAI_API_KEY" | codex login --with-api-key >/dev/null 2>&1 || true',
+    );
+  } else if (codexAuthFilePath !== undefined) {
+    const quoted = shellQuote(codexAuthFilePath);
+    lines.push(
+      `if [ -f ${quoted} ]; then mkdir -p "\${CODEX_HOME:-$HOME/.codex}"`,
+      `cp ${quoted} "\${CODEX_HOME:-$HOME/.codex}/auth.json"`,
+      `chmod 600 "\${CODEX_HOME:-$HOME/.codex}/auth.json"`,
+      "fi",
+    );
+  }
+
+  lines.push(command);
+  return lines.join("; ");
 }
 
 function createShellCommandRunner(

--- a/test/sandbox-execution.test.ts
+++ b/test/sandbox-execution.test.ts
@@ -7,6 +7,7 @@ import {
   createHostShellRunner,
   createHostWorkspace,
   createLineStreamSink,
+  hostCommandWithCodexAuth,
 } from "../src/sandbox-execution.js";
 
 async function withWorkspace(
@@ -100,6 +101,32 @@ test("host shell runner leaves git askpass unset without a GitHub token", async 
     assert.equal(result.exitCode, 0);
     assert.equal(result.stdout, "unset");
   });
+});
+
+test("codex auth logs in with the API key when one is present", () => {
+  const wrapped = hostCommandWithCodexAuth("codex exec --model gpt", undefined, {
+    OPENAI_API_KEY: "sk-test",
+  });
+
+  assert.match(wrapped, /codex login --with-api-key/);
+  assert.match(wrapped, /CODEX_HOME="\$\(mktemp -d\)"/);
+  assert.doesNotMatch(wrapped, /cp .*auth\.json/);
+  assert.ok(wrapped.endsWith("codex exec --model gpt"));
+});
+
+test("codex auth copies the OAuth file when no API key is present", () => {
+  const wrapped = hostCommandWithCodexAuth(
+    "codex exec --model gpt",
+    "/host/.codex/auth.json",
+    {},
+  );
+
+  assert.match(wrapped, /cp '\/host\/\.codex\/auth\.json'/);
+  assert.doesNotMatch(wrapped, /codex login/);
+});
+
+test("codex auth is a no-op for commands without credentials", () => {
+  assert.equal(hostCommandWithCodexAuth("git status", undefined, {}), "git status");
 });
 
 test("line stream sink redacts complete lines and flushes the remainder", () => {


### PR DESCRIPTION
Stacked on #91 (which is on #90).

## Problem

Setting `OPENAI_API_KEY` didn't stop codex from 401-ing:

```
codex_api::endpoint::responses_websocket: 401 Unauthorized, url: wss://api.openai.com/v1/responses
ERROR: unexpected status 401: Missing bearer or basic authentication in header
```

`responses_websocket` is codex's **ChatGPT/OAuth** transport. codex decides its auth from `CODEX_HOME/auth.json` (`codex login`), **not** the `OPENAI_API_KEY` env var. So if a ChatGPT login exists (expired) — or on a fresh runner with no login — codex tries OAuth and ignores the key → 401.

## Fix

When an API key is present, log codex in with it before running, into an **isolated CODEX_HOME**:

```sh
CODEX_HOME="$(mktemp -d)"; export CODEX_HOME
printf %s "$OPENAI_API_KEY" | codex login --with-api-key >/dev/null 2>&1 || true
<command>
```

Applied in both the host (direct) and Docker runners. Effects:
- codex uses the **API key** (no OAuth websocket, no 401).
- the user's real `~/.codex` is **untouched** (no clobbering their login).
- codex doesn't load the user's personal config, so **MCP servers and reasoning-effort inherit are skipped** → cleaner, faster, deterministic runs (this also removes the `rmcp` Linear MCP auth noise seen with `--verbose`).

The OAuth-file path is unchanged and used only when no key is set. Real credential flow never sets both (`OPENAI_API_KEY` present ⇒ `codexAuthFilePath` null).

## Tests

`hostCommandWithCodexAuth`: API key → `codex login --with-api-key` + isolated `CODEX_HOME`, no `cp`; no key + auth file → `cp …/auth.json`, no login; neither → passthrough. Full suite green (131).

## Caveat for users

With API-key auth, the `--model` must be one your **API account** can access. `gpt-5.5` may be ChatGPT-only; if you rely on a ChatGPT plan, prefer OAuth (`codex login`, no `OPENAI_API_KEY`) instead of a platform API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)