### PR TITLE
fix: install bubblewrap for the Codex sandbox on Linux

### DIFF
--- a/.github/workflows/issue-run.yml
+++ b/.github/workflows/issue-run.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Install Codex CLI
         run: npm install -g "@openai/codex@${CODEX_CLI_VERSION}"
 
+      - name: Install bubblewrap for the Codex sandbox
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends bubblewrap
+
       - name: Write Codex Cage credentials
         run: |
           {

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -4,6 +4,7 @@ ARG CODEX_CLI_VERSION=0.125.0
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
+    bubblewrap \
     ca-certificates \
     curl \
     git \


### PR DESCRIPTION
## Problem

On Linux, Codex uses **bubblewrap** for `--sandbox`. When it's missing it warns and falls back to a vendored copy:

```
warning: Codex could not find bubblewrap on PATH. Install bubblewrap with your OS package manager. ... Codex will use the vendored bubblewrap in the meantime.
```

It's non-fatal (runs still work), but noisy — and it appears in every Docker-mode / runner run.

## Fix

Install `bubblewrap` in the two Linux environments Codex runs in:

- **Base image** (`docker/base/Dockerfile`) — covers Docker mode and any `container:` job.
- **issue-run workflow** — a step on the ubuntu runner (direct mode).

No effect on macOS local runs (they use Seatbelt, not bubblewrap).

## Note

The base-image change only takes effect once the base image is **rebuilt/republished** (via the base-image workflow). The workflow-step change takes effect on the next run after merge.

Independent of the other open PRs (branches from main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)