### PR TITLE
chore: default the agent model to gpt-5.4-mini

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -90,7 +90,7 @@ runtime:
   dockerfile: null
 
 agent:
-  model: gpt-5.4
+  model: gpt-5.4-mini
   max_iterations: 5
   max_review_cycles: 2
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,11 +19,15 @@ export const codexCageConfigSchema = z
       .default(() => ({ image: defaultSandboxImage, dockerfile: null })),
     agent: z
       .object({
-        model: z.string().default("gpt-5.4"),
+        model: z.string().default("gpt-5.4-mini"),
         max_iterations: z.number().int().positive().default(5),
         max_review_cycles: z.number().int().nonnegative().default(2),
       })
-      .default(() => ({ model: "gpt-5.4", max_iterations: 5, max_review_cycles: 2 })),
+      .default(() => ({
+        model: "gpt-5.4-mini",
+        max_iterations: 5,
+        max_review_cycles: 2,
+      })),
     timeouts: z
       .object({
         total_minutes: z.number().int().positive().default(90),

--- a/src/init.ts
+++ b/src/init.ts
@@ -32,7 +32,7 @@ runtime:
   dockerfile: null
 
 agent:
-  model: gpt-5.5
+  model: gpt-5.4-mini
   max_iterations: 5
   max_review_cycles: 2
 


### PR DESCRIPTION
Changes the default `agent.model` to `gpt-5.4-mini`:

- `src/config.ts` — schema default (field + object fallback) `gpt-5.4` → `gpt-5.4-mini`.
- `src/init.ts` — generated `.codex-cage.yml` template (was `gpt-5.5`) → `gpt-5.4-mini`.
- `docs/workflow.md` — schema example aligned.

Any run that doesn't set `agent.model` — including this repo's own root `.codex-cage.yml` (which the issue-run workflow uses) — now defaults to `gpt-5.4-mini`. Override per-repo via `agent.model` or per-run via `--model`.

Full suite green (131).

🤖 Generated with [Claude Code](https://claude.com/claude-code)