### PR TITLE
fix: keep the isolated CODEX_HOME under $HOME, not /tmp

### DIFF
--- a/src/docker.ts
+++ b/src/docker.ts
@@ -414,7 +414,10 @@ function commandWithCodexAuth(
     // Log Codex in with the API key into an isolated CODEX_HOME so it uses the
     // key instead of a ChatGPT/OAuth login, and does not touch the real config.
     lines.push(
-      'CODEX_HOME="$(mktemp -d)"; export CODEX_HOME',
+      // Keep CODEX_HOME under $HOME, not /tmp: Codex refuses to create its
+      // helper binaries (apply_patch, etc.) under a world-writable temp dir,
+      // which would leave it unable to edit files.
+      'CODEX_HOME="$(mktemp -d "${HOME:-/root}/.codex-cage-home.XXXXXX")"; export CODEX_HOME',
       'printf %s "$OPENAI_API_KEY" | codex login --with-api-key >/dev/null 2>&1 || true',
     );
   } else if (codexAuthFilePath !== undefined) {

--- a/src/sandbox-execution.ts
+++ b/src/sandbox-execution.ts
@@ -299,7 +299,10 @@ export function hostCommandWithCodexAuth(
     // key instead of any ChatGPT/OAuth login, without touching the user's
     // ~/.codex (config and MCP servers are skipped too, keeping runs clean).
     lines.push(
-      'CODEX_HOME="$(mktemp -d)"; export CODEX_HOME',
+      // Keep CODEX_HOME under $HOME, not /tmp: Codex refuses to create its
+      // helper binaries (apply_patch, etc.) under a world-writable temp dir,
+      // which would leave it unable to edit files.
+      'CODEX_HOME="$(mktemp -d "${HOME:-/root}/.codex-cage-home.XXXXXX")"; export CODEX_HOME',
       'printf %s "$OPENAI_API_KEY" | codex login --with-api-key >/dev/null 2>&1 || true',
     );
   } else if (codexAuthFilePath !== undefined) {

--- a/test/sandbox-execution.test.ts
+++ b/test/sandbox-execution.test.ts
@@ -109,7 +109,11 @@ test("codex auth logs in with the API key when one is present", () => {
   });
 
   assert.match(wrapped, /codex login --with-api-key/);
-  assert.match(wrapped, /CODEX_HOME="\$\(mktemp -d\)"/);
+  // CODEX_HOME must live under $HOME, not /tmp (Codex refuses helper binaries there).
+  assert.match(
+    wrapped,
+    /CODEX_HOME="\$\(mktemp -d "\$\{HOME:-\/root\}\/\.codex-cage-home/,
+  );
   assert.doesNotMatch(wrapped, /cp .*auth\.json/);
   assert.ok(wrapped.endsWith("codex exec --model gpt"));
 });


### PR DESCRIPTION
## Problem

#93 set the isolated `CODEX_HOME` to `mktemp -d` (which lands in `/tmp`). Codex refuses to create its helper binaries there:

```
WARNING: Refusing to create helper binaries under temporary dir "/tmp" (codex_home: "/tmp/tmp.XXXX")
```

Those helpers include the file-editing tools (`apply_patch`, etc.). Without them Codex can't edit files → it produces an **empty diff** → the independent review correctly blocks ("no evidence README was changed"). This is the real cause of the recent `review_blocking` / empty-diff runs — auth (#93) and bubblewrap (#95) were already working; the model was being called (tokens burned) but couldn't write files.

## Fix

Create the isolated `CODEX_HOME` under `$HOME` instead of `/tmp`, in both the host and Docker runners:

```sh
CODEX_HOME="$(mktemp -d "${HOME:-/root}/.codex-cage-home.XXXXXX")"; export CODEX_HOME
```

`$HOME` (e.g. `/home/runner`, `/home/agent`) isn't a world-writable temp dir, so Codex will create its helpers and can edit files.

## Test

Updated the api-key auth test to assert the `$HOME`-based CODEX_HOME. Full suite green (131).

Branches from main (independent of the open model-default PR #96).

🤖 Generated with [Claude Code](https://claude.com/claude-code)