### PR TITLE
fix: bypass Codex's own sandbox in direct mode

### DIFF
--- a/src/run-workflow.ts
+++ b/src/run-workflow.ts
@@ -449,6 +449,7 @@ async function runImplementationLoop(input: {
           model: input.context.model,
           sandbox: "workspace-write",
           prompt,
+          bypassSandbox: input.context.executionMode === "direct",
         }),
         input.redactor,
         runtimeCommandCredentials("implement", input.context),

--- a/src/run/gates.ts
+++ b/src/run/gates.ts
@@ -136,7 +136,11 @@ export async function runReviewGate(input: {
       reviewPolicyStatus,
       resultMetadata,
       readCurrentDiff: async () => await readCurrentDiff(input.shell),
-      runner: createReviewAgentRunner(input.shell, reviewCredentials),
+      runner: createReviewAgentRunner(
+        input.shell,
+        reviewCredentials,
+        input.context.executionMode === "direct",
+      ),
       ...(reviewCredentials.env === undefined ? {} : { env: reviewCredentials.env }),
     });
 

--- a/src/sandbox-execution.ts
+++ b/src/sandbox-execution.ts
@@ -218,6 +218,7 @@ export function createGhCommandRunner(
 export function createReviewAgentRunner(
   shell: ShellRunner,
   options?: DockerCommandOptions,
+  bypassSandbox?: boolean,
 ): ReviewAgentRunner {
   return {
     async run(input): Promise<string> {
@@ -231,6 +232,7 @@ export function createReviewAgentRunner(
         sandbox: "read-only",
         outputSchemaPath,
         prompt: input.prompt,
+        bypassSandbox,
       })}`;
       const result = await shell.run(command, options);
 
@@ -248,14 +250,20 @@ export function codexExecCommand(input: {
   sandbox: "read-only" | "workspace-write";
   outputSchemaPath?: string | undefined;
   prompt: string;
+  bypassSandbox?: boolean | undefined;
 }): string {
-  const args = [
-    "codex exec",
-    "--model",
-    shellQuote(input.model),
-    "--sandbox",
-    shellQuote(input.sandbox),
-  ];
+  const args = ["codex exec", "--model", shellQuote(input.model)];
+
+  if (input.bypassSandbox === true) {
+    // Direct mode runs on an already-isolated, ephemeral runner where Codex's
+    // own bubblewrap sandbox cannot create network namespaces
+    // ("bwrap: loopback: ... Operation not permitted"). Skip Codex's sandbox
+    // and rely on the runner's isolation. Only safe because the host is
+    // externally sandboxed.
+    args.push("--dangerously-bypass-approvals-and-sandbox");
+  } else {
+    args.push("--sandbox", shellQuote(input.sandbox));
+  }
 
   if (input.outputSchemaPath !== undefined) {
     args.push("--output-schema", shellQuote(input.outputSchemaPath));

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -214,6 +214,16 @@ verify:
         details.phases.map((phase) => phase.name),
         ["preflight", "cloning", "setup", "implement", "verify", "review", "pr"],
       );
+
+      // Direct mode bypasses Codex's sandbox (the runner is already isolated);
+      // Docker mode keeps it.
+      const implementCommand =
+        shell.commands.find((command) => command.includes("codex exec")) ?? "";
+      if (mode === "direct") {
+        assert.match(implementCommand, /--dangerously-bypass-approvals-and-sandbox/);
+      } else {
+        assert.match(implementCommand, /--sandbox 'workspace-write'/);
+      }
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }

--- a/test/sandbox-execution.test.ts
+++ b/test/sandbox-execution.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
+  codexExecCommand,
   createHostShellRunner,
   createHostWorkspace,
   createLineStreamSink,
@@ -127,6 +128,29 @@ test("codex auth copies the OAuth file when no API key is present", () => {
 
 test("codex auth is a no-op for commands without credentials", () => {
   assert.equal(hostCommandWithCodexAuth("git status", undefined, {}), "git status");
+});
+
+test("codex exec uses the sandbox flag by default", () => {
+  const command = codexExecCommand({
+    model: "gpt",
+    sandbox: "workspace-write",
+    prompt: "do it",
+  });
+
+  assert.match(command, /--sandbox 'workspace-write'/);
+  assert.doesNotMatch(command, /--dangerously-bypass-approvals-and-sandbox/);
+});
+
+test("codex exec bypasses the sandbox in direct mode", () => {
+  const command = codexExecCommand({
+    model: "gpt",
+    sandbox: "workspace-write",
+    prompt: "do it",
+    bypassSandbox: true,
+  });
+
+  assert.match(command, /--dangerously-bypass-approvals-and-sandbox/);
+  assert.doesNotMatch(command, /--sandbox/);
 });
 
 test("line stream sink redacts complete lines and flushes the remainder", () => {


### PR DESCRIPTION
## Problem

On GitHub-hosted runners, Codex's bubblewrap sandbox can't create the network namespace it needs:

```
bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted
Unable to spawn codex-linux-sandbox
```

So `codex exec` couldn't run shell commands or apply patches → **empty diff** → the independent review blocked **every** run ("no evidence README was changed"). Auth (#93), bubblewrap install (#95), and CODEX_HOME-off-/tmp (#97) were all necessary but not sufficient — the runner forbids the sandbox's network-namespace setup outright, which no package install or `sysctl` fixes.

## Fix

Direct mode already runs on an **isolated, ephemeral runner**, so Codex's inner sandbox is redundant. In direct mode, pass `--dangerously-bypass-approvals-and-sandbox` instead of `--sandbox <mode>` for both the implement and review `codex exec` calls. Its own `--help` says it is *"intended solely for running in environments that are externally sandboxed"* — exactly a GitHub runner.

Docker mode and local runs are unchanged (they keep `--sandbox workspace-write` / `read-only`), so the isolation guarantee holds where the host isn't disposable.

Threading: `codexExecCommand` gains `bypassSandbox`; the implement call (`run-workflow.ts`) and the review runner (`gates.ts` → `createReviewAgentRunner`) set it from `context.executionMode === "direct"`.

## Tests

- `codexExecCommand`: default emits `--sandbox`; `bypassSandbox` emits `--dangerously-bypass-approvals-and-sandbox` and drops `--sandbox`.
- The parameterized both-mode happy-path now asserts the implement command bypasses in direct mode and keeps `--sandbox` in docker mode.

Full suite green (133).

## Stacking

Independent of #96 (model default) and #97 (CODEX_HOME). All branch from main. This is the last piece for the direct-mode runner to actually edit files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)