### PR TITLE
feat: label the issue ready-for-review on a successful run

### DIFF
--- a/.github/workflows/issue-run.yml
+++ b/.github/workflows/issue-run.yml
@@ -66,6 +66,12 @@ jobs:
       - name: Run Codex Cage
         run: node dist/src/cli.js run "$ISSUE_URL" --verbose --result-json "$RUNNER_TEMP/result.json"
 
+      - name: Mark issue ready for review
+        if: success()
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --add-label 'codex-cage:ready-for-review'
+
       - name: Report failure
         if: failure()
         run: |


### PR DESCRIPTION
Adds a success terminal to the label state machine: when a run succeeds (a PR was opened), the workflow adds **`codex-cage:ready-for-review`** to the issue.

- New step runs `if: success()`, so it's mutually exclusive with the failure path (which adds `codex-cage:blocked`).
- Label `codex-cage:ready-for-review` created in the repo.

Full label lifecycle now:

| event | labels |
| --- | --- |
| trigger | `codex-cage:run` removed → `codex-cage:in-progress` |
| success | `codex-cage:ready-for-review` added, `in-progress` cleared |
| failure | `codex-cage:blocked` added, `in-progress` cleared |

Workflow-only change; branches from main, independent of the other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)